### PR TITLE
Link angle sliders to 3D wing view

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -48,20 +48,37 @@ function createAirfoilPoints(chord, thickness, camber, camberPos, resolution = 5
   return [...top, ...bottom];
 }
 
+function rotateAirfoil(points, angle, chord) {
+  const radians = (angle * Math.PI) / 180;
+  const cos = Math.cos(radians);
+  const sin = Math.sin(radians);
+  const pivotX = chord;
+  const pivotY = 0;
+  return points.map((p) => {
+    const dx = p.x - pivotX;
+    const dy = p.y - pivotY;
+    const xr = dx * cos - dy * sin + pivotX;
+    const yr = dx * sin + dy * cos + pivotY;
+    return new THREE.Vector2(xr, yr);
+  });
+}
+
 function createWingGeometry(rootParams, tipParams, sweep, mirrored) {
-  const rootPoints = createAirfoilPoints(
+  let rootPoints = createAirfoilPoints(
     rootParams.chord,
     rootParams.thickness,
     rootParams.camber,
     rootParams.camberPos
   );
+  rootPoints = rotateAirfoil(rootPoints, rootParams.angle || 0, rootParams.chord);
 
-  const tipPoints = createAirfoilPoints(
+  let tipPoints = createAirfoilPoints(
     tipParams.chord,
     tipParams.thickness,
     tipParams.camber,
     tipParams.camberPos
   );
+  tipPoints = rotateAirfoil(tipPoints, tipParams.angle || 0, tipParams.chord);
 
   const rootShape = new THREE.Shape(rootPoints);
   const tipShape = new THREE.Shape(tipPoints);
@@ -133,6 +150,7 @@ export default function App() {
     thickness: { value: 0.12, min: 0.05, max: 0.25 },
     camber: { value: 0.02, min: 0, max: 0.1 },
     camberPos: { value: 0.4, min: 0.1, max: 0.9 },
+    angle: { value: 0, min: -15, max: 15, step: 0.1, label: 'Angle of Attack (°)' },
   });
 
   const tipParams = useControls('Tip Airfoil', {
@@ -140,6 +158,7 @@ export default function App() {
     thickness: { value: 0.12, min: 0.05, max: 0.25 },
     camber: { value: 0.015, min: 0, max: 0.1 },
     camberPos: { value: 0.4, min: 0.1, max: 0.9 },
+    angle: { value: 0, min: -15, max: 15, step: 0.1, label: 'Angle of Attack (°)' },
   });
 
   return (
@@ -166,6 +185,7 @@ export default function App() {
           thickness={rootParams.thickness}
           camber={rootParams.camber}
           camberPos={rootParams.camberPos}
+          angle={rootParams.angle}
           label="Root Airfoil"
         />
         <AirfoilPreview
@@ -174,6 +194,7 @@ export default function App() {
           thickness={tipParams.thickness}
           camber={tipParams.camber}
           camberPos={tipParams.camberPos}
+          angle={tipParams.angle}
           label="Tip Airfoil"
         />
       </div>

--- a/src/components/AirfoilPreview.jsx
+++ b/src/components/AirfoilPreview.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import * as THREE from 'three';
-import { useControls } from 'leva';
 
 function createAirfoilPoints(chord, thickness, camber, camberPos, resolution = 50) {
   const x = Array.from({ length: resolution }, (_, i) => i / (resolution - 1));
@@ -44,10 +43,7 @@ function createAirfoilPoints(chord, thickness, camber, camberPos, resolution = 5
   return [...top, ...bottom];
 }
 
-export default function AirfoilPreview({ chord, thickness, camber, camberPos, label }) {
-  const { angle } = useControls(label, {
-    angle: { value: 0, min: -15, max: 15, step: 0.1, label: 'Angle of Attack (°)' }
-  });
+export default function AirfoilPreview({ chord, thickness, camber, camberPos, angle = 0, label }) {
 
   const points = createAirfoilPoints(chord, thickness, camber, camberPos);
 


### PR DESCRIPTION
## Summary
- pass angle controls from `App` to the previews and wing geometry
- rotate root and tip sections in the 3D wing based on angle
- simplify `AirfoilPreview` to accept an angle prop

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68795ce97ff8833083c198f7b380c108