### PR TITLE
Fix build failure due to stray tokens

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -53,14 +53,8 @@ function rotateAirfoil(points, angle, chord, pivotRatio = 1) {
   const cos = Math.cos(radians);
   const sin = Math.sin(radians);
   const pivotX = chord * pivotRatio;
-
-function rotateAirfoil(points, angle, chord) {
-  const radians = (angle * Math.PI) / 180;
-  const cos = Math.cos(radians);
-  const sin = Math.sin(radians);
-  const pivotX = chord;
-main
   const pivotY = 0;
+
   return points.map((p) => {
     const dx = p.x - pivotX;
     const dy = p.y - pivotY;
@@ -85,8 +79,6 @@ function createWingGeometry(rootParams, tipParams, sweep, mirrored) {
     1
   );
 
-  rootPoints = rotateAirfoil(rootPoints, rootParams.angle || 0, rootParams.chord);
- main
 
   let tipPoints = createAirfoilPoints(
     tipParams.chord,
@@ -102,8 +94,6 @@ function createWingGeometry(rootParams, tipParams, sweep, mirrored) {
     (tipParams.pivotPercent ?? 100) / 100
   );
 
-  tipPoints = rotateAirfoil(tipPoints, tipParams.angle || 0, tipParams.chord);
-main
 
   const rootShape = new THREE.Shape(rootPoints);
   const tipShape = new THREE.Shape(tipPoints);
@@ -192,8 +182,6 @@ export default function App() {
       step: 1,
       label: 'Rotation Center (%)',
     },
-
-main
   });
 
   return (
@@ -232,7 +220,6 @@ main
           angle={tipParams.angle}
  //codex/make-angle-of-attack-sliders-affect-3d-view
           pivotPercent={tipParams.pivotPercent}
-main
           label="Tip Airfoil"
         />
       </div>

--- a/src/components/AirfoilPreview.jsx
+++ b/src/components/AirfoilPreview.jsx
@@ -46,9 +46,6 @@ function createAirfoilPoints(chord, thickness, camber, camberPos, resolution = 5
 //codex/make-angle-of-attack-sliders-affect-3d-view
 export default function AirfoilPreview({ chord, thickness, camber, camberPos, angle = 0, pivotPercent = 100, label }) {
 
-export default function AirfoilPreview({ chord, thickness, camber, camberPos, angle = 0, label }) {
- main
-
   const points = createAirfoilPoints(chord, thickness, camber, camberPos);
 
   // Rotate points by angle of attack (pivot around trailing edge)


### PR DESCRIPTION
## Summary
- clean stray tokens from `App.jsx` and `AirfoilPreview.jsx`
- remove duplicate function definitions
- fix `rotateAirfoil` implementation

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687c152ce21c833087dfd212358ae597