### PR TITLE
Show panel folders based on enable flags

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -167,20 +167,6 @@ export default function App() {
     dihedral: { value: 0, min: -10, max: 10, step: 0.1, label: 'Dihedral (°)' },
   });
 
-  const tipParams = useControls('Tip Airfoil', {
-    chord: { value: 60, min: 10, max: 400 },
-    thickness: { value: 0.12, min: 0.05, max: 0.25 },
-    camber: { value: 0.015, min: 0, max: 0.1 },
-    camberPos: { value: 0.4, min: 0.1, max: 0.9 },
-    angle: { value: 0, min: -15, max: 15, step: 0.1, label: 'Angle of Attack (°)' },
-    pivotPercent: {
-      value: 100,
-      min: 0,
-      max: 100,
-      step: 1,
-      label: 'Rotation Center (%)',
-    },
-  });
 
   const panel1Params = useControls('Panel 1 Airfoil', {
     chord: { value: 80, min: 10, max: 400 },
@@ -196,7 +182,7 @@ export default function App() {
       label: 'Rotation Center (%)',
     },
     dihedral: { value: 0, min: -10, max: 10, step: 0.1, label: 'Dihedral (°)' },
-  });
+  }, { render: () => enablePanel1 });
 
   const panel2Params = useControls('Panel 2 Airfoil', {
     chord: { value: 70, min: 10, max: 400 },
@@ -212,6 +198,21 @@ export default function App() {
       label: 'Rotation Center (%)',
     },
     dihedral: { value: 0, min: -10, max: 10, step: 0.1, label: 'Dihedral (°)' },
+  }, { render: () => enablePanel2 });
+
+  const tipParams = useControls('Tip Airfoil', {
+    chord: { value: 60, min: 10, max: 400 },
+    thickness: { value: 0.12, min: 0.05, max: 0.25 },
+    camber: { value: 0.015, min: 0, max: 0.1 },
+    camberPos: { value: 0.4, min: 0.1, max: 0.9 },
+    angle: { value: 0, min: -15, max: 15, step: 0.1, label: 'Angle of Attack (°' },
+    pivotPercent: {
+      value: 100,
+      min: 0,
+      max: 100,
+      step: 1,
+      label: 'Rotation Center (%)',
+    },
   });
 
   const sections = [rootParams];


### PR DESCRIPTION
## Summary
- insert conditional `render` settings for Panel folders
- move Panel folders before Tip folder

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687c4b77cbb48330982965582610a63f