### PR TITLE
Add fuselage controls and geometry

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import { useControls, Leva } from 'leva';
 import * as THREE from 'three';
 import './App.css';
 import AirfoilPreview from './components/AirfoilPreview';
+import Fuselage from './components/Fuselage';
 // Trigger rebuild
 function createAirfoilPoints(chord, thickness, camber, camberPos, resolution = 50) {
   const x = Array.from({ length: resolution }, (_, i) => i / (resolution - 1));
@@ -215,6 +216,13 @@ export default function App() {
     },
   });
 
+  const fuselageParams = useControls('Fuselage', {
+    length: { value: 200, min: 50, max: 600 },
+    width: { value: 40, min: 10, max: 200 },
+    taper: { value: 0.8, min: 0.1, max: 1, step: 0.01 },
+    cornerDiameter: { value: 10, min: 0, max: 50, label: 'Corner Diameter' },
+  });
+
   const sections = [rootParams];
   if (enablePanel1) sections.push(panel1Params);
   if (enablePanel2) sections.push(panel2Params);
@@ -288,6 +296,12 @@ export default function App() {
         <Canvas camera={{ position: [0, 0, 400], fov: 50 }}>
           <ambientLight intensity={0.5} />
           <directionalLight position={[1, 2, 3]} intensity={1} />
+          <Fuselage
+            length={fuselageParams.length}
+            width={fuselageParams.width}
+            taper={fuselageParams.taper}
+            cornerDiameter={fuselageParams.cornerDiameter}
+          />
           <Wing
             sections={sections}
             span={span}

--- a/src/components/Fuselage.jsx
+++ b/src/components/Fuselage.jsx
@@ -1,0 +1,69 @@
+import React, { useMemo } from 'react';
+import * as THREE from 'three';
+
+function createRoundedRectShape(size, radius) {
+  const half = size / 2;
+  const r = Math.min(radius, half);
+  const shape = new THREE.Shape();
+  shape.moveTo(-half + r, -half);
+  shape.lineTo(half - r, -half);
+  shape.quadraticCurveTo(half, -half, half, -half + r);
+  shape.lineTo(half, half - r);
+  shape.quadraticCurveTo(half, half, half - r, half);
+  shape.lineTo(-half + r, half);
+  shape.quadraticCurveTo(-half, half, -half, half - r);
+  shape.lineTo(-half, -half + r);
+  shape.quadraticCurveTo(-half, -half, -half + r, -half);
+  return shape;
+}
+
+function createFuselageGeometry(length, width, taper, cornerDiameter) {
+  const radius = cornerDiameter / 2;
+  const tailShape = createRoundedRectShape(width, radius);
+  const noseShape = createRoundedRectShape(width * taper, radius * taper);
+  const tail = tailShape.getPoints(32);
+  const nose = noseShape.getPoints(32);
+
+  const vertices = [];
+  const indices = [];
+  const startX = -length / 2;
+  const endX = length / 2;
+
+  for (let i = 0; i < tail.length; i++) {
+    const tp = tail[i];
+    const np = nose[i];
+    vertices.push(startX, tp.x, tp.y);
+    vertices.push(endX, np.x, np.y);
+  }
+
+  for (let i = 0; i < tail.length - 1; i++) {
+    const r1 = 2 * i;
+    const t1 = 2 * i + 1;
+    const r2 = 2 * (i + 1);
+    const t2 = 2 * (i + 1) + 1;
+    indices.push(r1, t1, r2);
+    indices.push(t1, t2, r2);
+  }
+  const last = tail.length - 1;
+  indices.push(2 * last, 2 * last + 1, 0);
+  indices.push(2 * last + 1, 1, 0);
+
+  const geom = new THREE.BufferGeometry();
+  geom.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3));
+  geom.setIndex(indices);
+  geom.computeVertexNormals();
+  return geom;
+}
+
+export default function Fuselage({ length, width, taper, cornerDiameter }) {
+  const geom = useMemo(
+    () => createFuselageGeometry(length, width, taper, cornerDiameter),
+    [length, width, taper, cornerDiameter]
+  );
+
+  return (
+    <mesh geometry={geom}>
+      <meshStandardMaterial color="gray" side={THREE.DoubleSide} />
+    </mesh>
+  );
+}


### PR DESCRIPTION
## Summary
- create `Fuselage` component with rounded rectangular cross-section
- expose fuselage length, width, taper and corner radius controls
- render fuselage mesh in canvas

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687c76208f4c8330a73dcc36b33819dd