### PR TITLE
Add independent fuselage taper controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ If you are developing a production application, we recommend using TypeScript wi
 
 ## Features
 - Adjustable wing mount position along the fuselage using the new "Mount Position" control.
+- Independent vertical and horizontal fuselage taper with adjustable start positions.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -223,7 +223,10 @@ export default function App() {
   const fuselageParams = useControls('Fuselage', {
     length: { value: 200, min: 50, max: 600 },
     width: { value: 40, min: 10, max: 200 },
-    taper: { value: 0.8, min: 0.1, max: 1, step: 0.01 },
+    taperH: { value: 0.8, min: 0.1, max: 1, step: 0.01, label: 'Horizontal Taper' },
+    taperV: { value: 0.8, min: 0.1, max: 1, step: 0.01, label: 'Vertical Taper' },
+    taperPosH: { value: 0, min: 0, max: 1, step: 0.01, label: 'Horizontal Taper Start' },
+    taperPosV: { value: 0, min: 0, max: 1, step: 0.01, label: 'Vertical Taper Start' },
     cornerDiameter: { value: 10, min: 0, max: 50, label: 'Corner Diameter' },
   });
 
@@ -303,7 +306,10 @@ export default function App() {
           <Fuselage
             length={fuselageParams.length}
             width={fuselageParams.width}
-            taper={fuselageParams.taper}
+            taperH={fuselageParams.taperH}
+            taperV={fuselageParams.taperV}
+            taperPosH={fuselageParams.taperPosH}
+            taperPosV={fuselageParams.taperPosV}
             cornerDiameter={fuselageParams.cornerDiameter}
           />
           <Wing

--- a/src/components/Fuselage.jsx
+++ b/src/components/Fuselage.jsx
@@ -1,52 +1,90 @@
 import React, { useMemo } from 'react';
 import * as THREE from 'three';
 
-function createRoundedRectShape(size, radius) {
-  const half = size / 2;
-  const r = Math.min(radius, half);
+function createRoundedRectShape(width, height, radius) {
+  const halfW = width / 2;
+  const halfH = height / 2;
+  const r = Math.min(radius, halfW, halfH);
   const shape = new THREE.Shape();
-  shape.moveTo(-half + r, -half);
-  shape.lineTo(half - r, -half);
-  shape.quadraticCurveTo(half, -half, half, -half + r);
-  shape.lineTo(half, half - r);
-  shape.quadraticCurveTo(half, half, half - r, half);
-  shape.lineTo(-half + r, half);
-  shape.quadraticCurveTo(-half, half, -half, half - r);
-  shape.lineTo(-half, -half + r);
-  shape.quadraticCurveTo(-half, -half, -half + r, -half);
+  shape.moveTo(-halfW + r, -halfH);
+  shape.lineTo(halfW - r, -halfH);
+  shape.quadraticCurveTo(halfW, -halfH, halfW, -halfH + r);
+  shape.lineTo(halfW, halfH - r);
+  shape.quadraticCurveTo(halfW, halfH, halfW - r, halfH);
+  shape.lineTo(-halfW + r, halfH);
+  shape.quadraticCurveTo(-halfW, halfH, -halfW, halfH - r);
+  shape.lineTo(-halfW, -halfH + r);
+  shape.quadraticCurveTo(-halfW, -halfH, -halfW + r, -halfH);
   return shape;
 }
 
-function createFuselageGeometry(length, width, taper, cornerDiameter) {
+function createFuselageGeometry(
+  length,
+  width,
+  taperH,
+  taperV,
+  taperPosH,
+  taperPosV,
+  cornerDiameter,
+) {
   const radius = cornerDiameter / 2;
-  const tailShape = createRoundedRectShape(width, radius);
-  const noseShape = createRoundedRectShape(width * taper, radius * taper);
-  const tail = tailShape.getPoints(32);
-  const nose = noseShape.getPoints(32);
+
+  const positions = [0];
+  if (taperPosH > 0 && taperPosH < 1 && !positions.includes(taperPosH)) {
+    positions.push(taperPosH);
+  }
+  if (taperPosV > 0 && taperPosV < 1 && !positions.includes(taperPosV)) {
+    positions.push(taperPosV);
+  }
+  positions.push(1);
+  positions.sort((a, b) => a - b);
+
+  function scale(p, pos, taper) {
+    if (pos >= 1) return p < 1 ? 1 : taper;
+    if (p <= pos) return 1;
+    return 1 + ((p - pos) / (1 - pos)) * (taper - 1);
+  }
+
+  const pointArrays = positions.map((p) => {
+    const hScale = scale(p, taperPosH, taperH);
+    const vScale = scale(p, taperPosV, taperV);
+    const shape = createRoundedRectShape(
+      width * hScale,
+      width * vScale,
+      radius * Math.min(hScale, vScale),
+    );
+    return shape.getPoints(32);
+  });
 
   const vertices = [];
   const indices = [];
-  const startX = -length / 2;
-  const endX = length / 2;
+  let offset = 0;
 
-  for (let i = 0; i < tail.length; i++) {
-    const tp = tail[i];
-    const np = nose[i];
-    vertices.push(startX, tp.x, tp.y);
-    vertices.push(endX, np.x, np.y);
-  }
+  for (let s = 0; s < pointArrays.length - 1; s++) {
+    const startX = -length / 2 + length * positions[s];
+    const endX = -length / 2 + length * positions[s + 1];
+    const start = pointArrays[s];
+    const end = pointArrays[s + 1];
 
-  for (let i = 0; i < tail.length - 1; i++) {
-    const r1 = 2 * i;
-    const t1 = 2 * i + 1;
-    const r2 = 2 * (i + 1);
-    const t2 = 2 * (i + 1) + 1;
-    indices.push(r1, t1, r2);
-    indices.push(t1, t2, r2);
+    for (let i = 0; i < start.length; i++) {
+      vertices.push(startX, start[i].x, start[i].y);
+      vertices.push(endX, end[i].x, end[i].y);
+    }
+
+    for (let i = 0; i < start.length - 1; i++) {
+      const r1 = offset + 2 * i;
+      const t1 = offset + 2 * i + 1;
+      const r2 = offset + 2 * (i + 1);
+      const t2 = offset + 2 * (i + 1) + 1;
+      indices.push(r1, t1, r2);
+      indices.push(t1, t2, r2);
+    }
+    const last = start.length - 1;
+    indices.push(offset + 2 * last, offset + 2 * last + 1, offset);
+    indices.push(offset + 2 * last + 1, offset + 1, offset);
+
+    offset += start.length * 2;
   }
-  const last = tail.length - 1;
-  indices.push(2 * last, 2 * last + 1, 0);
-  indices.push(2 * last + 1, 1, 0);
 
   const geom = new THREE.BufferGeometry();
   geom.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3));
@@ -55,10 +93,27 @@ function createFuselageGeometry(length, width, taper, cornerDiameter) {
   return geom;
 }
 
-export default function Fuselage({ length, width, taper, cornerDiameter }) {
+export default function Fuselage({
+  length,
+  width,
+  taperH,
+  taperV,
+  taperPosH,
+  taperPosV,
+  cornerDiameter,
+}) {
   const geom = useMemo(
-    () => createFuselageGeometry(length, width, taper, cornerDiameter),
-    [length, width, taper, cornerDiameter]
+    () =>
+      createFuselageGeometry(
+        length,
+        width,
+        taperH,
+        taperV,
+        taperPosH,
+        taperPosV,
+        cornerDiameter,
+      ),
+    [length, width, taperH, taperV, taperPosH, taperPosV, cornerDiameter]
   );
 
   return (


### PR DESCRIPTION
## Summary
- update `Fuselage` geometry to support horizontal/vertical taper
- expose taper start positions and controls in `App`
- document new fuselage taper feature

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687c7e9531b08330aeb4a3524b9514ee