### PR TITLE
Add fuselage taper curvature controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ If you are developing a production application, we recommend using TypeScript wi
 ## Features
 - Adjustable wing mount position along the fuselage using the new "Mount Position" control.
 - Independent vertical and horizontal fuselage taper with adjustable start positions.
+- Curvature controls for both horizontal and vertical fuselage tapers.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -228,6 +228,8 @@ export default function App() {
     taperPosH: { value: 0, min: 0, max: 1, step: 0.01, label: 'Horizontal Taper Start' },
     taperPosV: { value: 0, min: 0, max: 1, step: 0.01, label: 'Vertical Taper Start' },
     cornerDiameter: { value: 10, min: 0, max: 50, label: 'Corner Diameter' },
+    curveH: { value: 1, min: 0.1, max: 5, step: 0.1, label: 'Horizontal Taper Curve' },
+    curveV: { value: 1, min: 0.1, max: 5, step: 0.1, label: 'Vertical Taper Curve' },
   });
 
   const sections = [rootParams];
@@ -311,6 +313,8 @@ export default function App() {
             taperPosH={fuselageParams.taperPosH}
             taperPosV={fuselageParams.taperPosV}
             cornerDiameter={fuselageParams.cornerDiameter}
+            curveH={fuselageParams.curveH}
+            curveV={fuselageParams.curveV}
           />
           <Wing
             sections={sections}

--- a/src/components/Fuselage.jsx
+++ b/src/components/Fuselage.jsx
@@ -26,6 +26,8 @@ function createFuselageGeometry(
   taperPosH,
   taperPosV,
   cornerDiameter,
+  curveH,
+  curveV,
 ) {
   const radius = cornerDiameter / 2;
 
@@ -39,15 +41,17 @@ function createFuselageGeometry(
   positions.push(1);
   positions.sort((a, b) => a - b);
 
-  function scale(p, pos, taper) {
+  function scale(p, pos, taper, curve) {
     if (pos >= 1) return p < 1 ? 1 : taper;
     if (p <= pos) return 1;
-    return 1 + ((p - pos) / (1 - pos)) * (taper - 1);
+    const t = (p - pos) / (1 - pos);
+    const curved = Math.pow(t, curve);
+    return 1 + curved * (taper - 1);
   }
 
   const pointArrays = positions.map((p) => {
-    const hScale = scale(p, taperPosH, taperH);
-    const vScale = scale(p, taperPosV, taperV);
+    const hScale = scale(p, taperPosH, taperH, curveH);
+    const vScale = scale(p, taperPosV, taperV, curveV);
     const shape = createRoundedRectShape(
       width * hScale,
       width * vScale,
@@ -101,6 +105,8 @@ export default function Fuselage({
   taperPosH,
   taperPosV,
   cornerDiameter,
+  curveH = 1,
+  curveV = 1,
 }) {
   const geom = useMemo(
     () =>
@@ -112,8 +118,10 @@ export default function Fuselage({
         taperPosH,
         taperPosV,
         cornerDiameter,
+        curveH,
+        curveV,
       ),
-    [length, width, taperH, taperV, taperPosH, taperPosV, cornerDiameter]
+    [length, width, taperH, taperV, taperPosH, taperPosV, cornerDiameter, curveH, curveV]
   );
 
   return (


### PR DESCRIPTION
## Summary
- add horizontal & vertical taper curvature parameters to Fuselage component
- expose curvature controls in the UI
- document new feature in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687ce45a1b5c833094a894349c7469fd