### PR TITLE
Add 3D view controls

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef } from 'react';
 import { Canvas } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
 import { useControls, Leva } from 'leva';
@@ -6,6 +6,7 @@ import * as THREE from 'three';
 import './App.css';
 import AirfoilPreview from './components/AirfoilPreview';
 import Fuselage from './components/Fuselage';
+import ViewControls from './components/ViewControls';
 // Trigger rebuild
 function createAirfoilPoints(chord, thickness, camber, camberPos, resolution = 50) {
   const x = Array.from({ length: resolution }, (_, i) => i / (resolution - 1));
@@ -153,6 +154,8 @@ function Wing({ sections, span, sweep, mirrored, mountHeight = 0, mountX = 0 }) 
 }
 
 export default function App() {
+  const controlsRef = useRef();
+  const groupRef = useRef();
   const { span, sweep, mirrored, enablePanel1, enablePanel2, mountHeight, mountX } = useControls('Wing Settings', {
     span: { value: 150, min: 10, max: 500 },
     sweep: { value: 0, min: -100, max: 100 },
@@ -301,30 +304,33 @@ export default function App() {
       </div>
 
       {/* Canvas */}
-      <div style={{ flex: 1 }}>
+      <div style={{ flex: 1, position: 'relative' }}>
         <Canvas camera={{ position: [0, 0, 400], fov: 50 }}>
           <ambientLight intensity={0.5} />
           <directionalLight position={[1, 2, 3]} intensity={1} />
-          <Fuselage
-            length={fuselageParams.length}
-            width={fuselageParams.width}
-            taperH={fuselageParams.taperH}
-            taperV={fuselageParams.taperV}
-            taperPosH={fuselageParams.taperPosH}
-            taperPosV={fuselageParams.taperPosV}
-            cornerDiameter={fuselageParams.cornerDiameter}
-            curveH={fuselageParams.curveH}
-            curveV={fuselageParams.curveV}
-          />
-          <Wing
-            sections={sections}
-            span={span}
-            sweep={sweep}
-            mirrored={mirrored}
-            mountHeight={mountHeight}
-            mountX={mountX}
-          />
-          <OrbitControls />
+          <group ref={groupRef}>
+            <Fuselage
+              length={fuselageParams.length}
+              width={fuselageParams.width}
+              taperH={fuselageParams.taperH}
+              taperV={fuselageParams.taperV}
+              taperPosH={fuselageParams.taperPosH}
+              taperPosV={fuselageParams.taperPosV}
+              cornerDiameter={fuselageParams.cornerDiameter}
+              curveH={fuselageParams.curveH}
+              curveV={fuselageParams.curveV}
+            />
+            <Wing
+              sections={sections}
+              span={span}
+              sweep={sweep}
+              mirrored={mirrored}
+              mountHeight={mountHeight}
+              mountX={mountX}
+            />
+          </group>
+          <OrbitControls ref={controlsRef} />
+          <ViewControls controls={controlsRef} targetGroup={groupRef} />
         </Canvas>
       </div>
     </div>

--- a/src/components/ViewControls.jsx
+++ b/src/components/ViewControls.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { useThree } from '@react-three/fiber';
+import { Html } from '@react-three/drei';
+import * as THREE from 'three';
+
+export default function ViewControls({ controls, targetGroup }) {
+  const { camera } = useThree();
+  const step = 20;
+  const angleStep = THREE.MathUtils.degToRad(15);
+
+  const slide = (dir) => {
+    camera.position.x += dir * step;
+    if (controls.current) {
+      controls.current.target.x += dir * step;
+      controls.current.update();
+    }
+  };
+
+  const rotate = () => {
+    const center = controls.current ? controls.current.target : new THREE.Vector3();
+    camera.position.sub(center);
+    camera.position.applyAxisAngle(new THREE.Vector3(0, 1, 0), angleStep);
+    camera.position.add(center);
+    if (controls.current) controls.current.update();
+  };
+
+  const centerView = () => {
+    if (!targetGroup.current) return;
+    const box = new THREE.Box3().setFromObject(targetGroup.current);
+    const c = new THREE.Vector3();
+    box.getCenter(c);
+    const offset = new THREE.Vector3().subVectors(camera.position, controls.current.target);
+    controls.current.target.copy(c);
+    camera.position.copy(c.clone().add(offset));
+    controls.current.update();
+  };
+
+  return (
+    <Html prepend>
+      <div style={{ position: 'absolute', bottom: 20, left: 20, display: 'flex', gap: '8px' }}>
+        <button onClick={() => slide(-1)}>◀</button>
+        <button onClick={centerView}>Center</button>
+        <button onClick={() => slide(1)}>▶</button>
+        <button onClick={rotate}>⟳</button>
+      </div>
+    </Html>
+  );
+}


### PR DESCRIPTION
## Summary
- add new ViewControls component for the canvas
- wire the overlay in `App.jsx` and wrap scene objects in a group
- expose camera controls through buttons for sliding, rotating and centering

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687ce7fc78348330b366c5c4f313aef5