### PR TITLE
Fix canvas resizing with browser window

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -44,6 +44,7 @@ html, body, #root {
   margin: 0;
   padding: 0;
   height: 100%;
+  width: 100%;
   overflow: hidden;
   font-family: sans-serif;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -304,8 +304,8 @@ export default function App() {
       </div>
 
       {/* Canvas */}
-      <div style={{ flex: 1, position: 'relative' }}>
-        <Canvas camera={{ position: [0, 0, 400], fov: 50 }}>
+      <div style={{ flex: 1, position: 'relative', height: '100%' }}>
+        <Canvas style={{ width: '100%', height: '100%' }} camera={{ position: [0, 0, 400], fov: 50 }}>
           <ambientLight intensity={0.5} />
           <directionalLight position={[1, 2, 3]} intensity={1} />
           <group ref={groupRef}>


### PR DESCRIPTION
## Summary
- ensure the 3D canvas fills its container
- set the html/body/root elements to 100% width

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687cf9f973988330891cbe7db0c28d01