### PR TITLE
Fix canvas sizing and camera centering

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,8 +1,11 @@
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  /* Ensure the React root spans the full viewport */
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  text-align: left;
 }
 
 .logo {


### PR DESCRIPTION
## Summary
- ensure React root spans the full viewport
- add ResizeHandler and CameraCenter helpers
- automatically center the camera on the aircraft and handle resize events

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d2b0c8a7c8330b9b4cbfd536aeb29