### PR TITLE
Improve 3D controls and mini view layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -219,10 +219,10 @@ export default function App() {
         <div
           style={{
             position: 'absolute',
-            bottom: 20,
-            left: '50%',
-            transform: 'translateX(-50%)',
+            top: 20,
+            left: 20,
             display: 'flex',
+            flexDirection: 'column',
             gap: '10px',
           }}
         >
@@ -235,6 +235,7 @@ export default function App() {
               mountHeight={mountHeight}
               mountX={mountX}
               fuselageParams={fuselageParams}
+              wireframe
             />
           </MiniView>
           <MiniView position={[0, 400, 0]} up={[0, 0, 1]}>
@@ -246,6 +247,7 @@ export default function App() {
               mountHeight={mountHeight}
               mountX={mountX}
               fuselageParams={fuselageParams}
+              wireframe
             />
           </MiniView>
         </div>

--- a/src/components/Aircraft.jsx
+++ b/src/components/Aircraft.jsx
@@ -11,6 +11,7 @@ export default function Aircraft({
   mountX,
   fuselageParams,
   groupRef,
+  wireframe = false,
 }) {
   return (
     <group ref={groupRef}>
@@ -24,6 +25,7 @@ export default function Aircraft({
         cornerDiameter={fuselageParams.cornerDiameter}
         curveH={fuselageParams.curveH}
         curveV={fuselageParams.curveV}
+        wireframe={wireframe}
       />
       <Wing
         sections={sections}
@@ -32,6 +34,7 @@ export default function Aircraft({
         mirrored={mirrored}
         mountHeight={mountHeight}
         mountX={mountX}
+        wireframe={wireframe}
       />
     </group>
   );

--- a/src/components/Fuselage.jsx
+++ b/src/components/Fuselage.jsx
@@ -107,6 +107,7 @@ export default function Fuselage({
   cornerDiameter,
   curveH = 1,
   curveV = 1,
+  wireframe = false,
 }) {
   const geom = useMemo(
     () =>
@@ -126,7 +127,7 @@ export default function Fuselage({
 
   return (
     <mesh geometry={geom}>
-      <meshStandardMaterial color="gray" side={THREE.DoubleSide} />
+      <meshStandardMaterial color="gray" side={THREE.DoubleSide} wireframe={wireframe} />
     </mesh>
   );
 }

--- a/src/components/MiniView.jsx
+++ b/src/components/MiniView.jsx
@@ -1,13 +1,33 @@
-import React from 'react';
-import { Canvas } from '@react-three/fiber';
+import React, { useRef, useLayoutEffect } from 'react';
+import { Canvas, useThree } from '@react-three/fiber';
+import * as THREE from 'three';
+
+function FitToObject({ groupRef }) {
+  const { camera, size } = useThree();
+  useLayoutEffect(() => {
+    if (!groupRef.current) return;
+    const box = new THREE.Box3().setFromObject(groupRef.current);
+    const sphere = box.getBoundingSphere(new THREE.Sphere());
+    camera.lookAt(sphere.center);
+    const zoom = Math.min(
+      size.width / (sphere.radius * 2),
+      size.height / (sphere.radius * 2),
+    ) * 0.9;
+    camera.zoom = zoom;
+    camera.updateProjectionMatrix();
+  }, [groupRef, camera, size]);
+  return null;
+}
 
 export default function MiniView({ position, up, children, style }) {
+  const groupRef = useRef();
   return (
     <div style={{ width: 200, height: 200, border: '1px solid #333', ...style }}>
       <Canvas orthographic camera={{ position, zoom: 1, up }} style={{ width: '100%', height: '100%' }}>
         <ambientLight intensity={0.5} />
         <directionalLight position={[1, 2, 3]} intensity={1} />
-        {children}
+        <group ref={groupRef}>{children}</group>
+        <FitToObject groupRef={groupRef} />
       </Canvas>
     </div>
   );

--- a/src/components/ViewControls.jsx
+++ b/src/components/ViewControls.jsx
@@ -35,8 +35,8 @@ export default function ViewControls({ controls, targetGroup }) {
   };
 
   return (
-    <Html prepend>
-      <div style={{ position: 'absolute', bottom: 20, left: 20, display: 'flex', flexDirection: 'column', gap: '4px' }}>
+    <Html fullscreen>
+      <div style={{ position: 'absolute', top: 20, left: 20, display: 'flex', flexDirection: 'column', gap: '4px' }}>
         <div style={{ display: 'flex', gap: '4px', justifyContent: 'center' }}>
           <button onClick={() => pan(0, 1)}>▲</button>
         </div>

--- a/src/components/Wing.jsx
+++ b/src/components/Wing.jsx
@@ -130,7 +130,7 @@ function createWingGeometry(sections, span, sweep, mirrored) {
   return wingGeom;
 }
 
-export default function Wing({ sections, span, sweep, mirrored, mountHeight = 0, mountX = 0 }) {
+export default function Wing({ sections, span, sweep, mirrored, mountHeight = 0, mountX = 0, wireframe = false }) {
   const geom = useMemo(() => {
     return createWingGeometry(sections, span, sweep, mirrored);
   }, [sections, span, sweep, mirrored]);
@@ -138,7 +138,7 @@ export default function Wing({ sections, span, sweep, mirrored, mountHeight = 0,
   return (
     <group position={[mountX, mountHeight, 0]}>
       <mesh geometry={geom}>
-        <meshStandardMaterial color="skyblue" side={THREE.DoubleSide} />
+        <meshStandardMaterial color="skyblue" side={THREE.DoubleSide} wireframe={wireframe} />
       </mesh>
     </group>
   );


### PR DESCRIPTION
## Summary
- keep view controls fixed in the upper left of the 3D view
- move mini preview windows to the left of the canvas
- render mini previews in wireframe and auto–fit view
- pass wireframe setting through Aircraft components

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687d37bdfcc4833083cf930545b53da6