### PR TITLE
Fix mini view alignment

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -219,7 +219,7 @@ export default function App() {
         <div
           style={{
             position: 'absolute',
-            top: 20,
+            bottom: 20,
             left: 20,
             display: 'flex',
             flexDirection: 'column',


### PR DESCRIPTION
## Summary
- set MiniView overlay to bottom-left of canvas

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687d3f1a77148330a21fb20fa95a26ae