### PR TITLE
Add optional fuselage nose section

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@ If you are developing a production application, we recommend using TypeScript wi
 - Curvature controls for both horizontal and vertical fuselage tapers.
 - Fuselage tapers now form smooth curves rather than abrupt angles.
 - Adjustable tail height relative to the nose using the new "Tail Height" control.
+- Optional nose section that tapers in the opposite direction of the main fuselage.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -116,6 +116,7 @@ export default function App() {
     curveH: { value: 1, min: 0.1, max: 5, step: 0.1, label: 'Horizontal Taper Curve' },
     curveV: { value: 1, min: 0.1, max: 5, step: 0.1, label: 'Vertical Taper Curve' },
     tailHeight: { value: 0, min: -100, max: 100, step: 1, label: 'Tail Height' },
+    noseLength: { value: 0, min: 0, max: 300, step: 1, label: 'Nose Length' },
   });
 
   const sections = [rootParams];

--- a/src/components/Aircraft.jsx
+++ b/src/components/Aircraft.jsx
@@ -25,6 +25,7 @@ export default function Aircraft({
         curveH={fuselageParams.curveH}
         curveV={fuselageParams.curveV}
         tailHeight={fuselageParams.tailHeight}
+        noseLength={fuselageParams.noseLength}
         wireframe={wireframe}
       />
       <Wing

--- a/src/components/Fuselage.jsx
+++ b/src/components/Fuselage.jsx
@@ -106,6 +106,7 @@ export default function Fuselage({
   curveH = 1,
   curveV = 1,
   tailHeight = 0,
+  noseLength = 0,
   wireframe = false,
 }) {
   const geom = useMemo(
@@ -125,9 +126,33 @@ export default function Fuselage({
     [length, width, taperH, taperV, taperPosH, taperPosV, cornerDiameter, curveH, curveV, tailHeight]
   );
 
+  const noseGeom = useMemo(() => {
+    if (noseLength <= 0) return null;
+    return createFuselageGeometry(
+      noseLength,
+      width * taperH,
+      1 / taperH,
+      1 / taperV,
+      taperPosH,
+      taperPosV,
+      cornerDiameter * Math.min(taperH, taperV),
+      curveH,
+      curveV,
+    );
+  }, [noseLength, width, taperH, taperV, taperPosH, taperPosV, cornerDiameter, curveH, curveV]);
+
+  const nosePos = useMemo(() => [-length / 2 - noseLength / 2, 0, 0], [length, noseLength]);
+
   return (
-    <mesh geometry={geom}>
-      <meshStandardMaterial color="gray" side={THREE.DoubleSide} wireframe={wireframe} />
-    </mesh>
+    <group>
+      <mesh geometry={geom}>
+        <meshStandardMaterial color="gray" side={THREE.DoubleSide} wireframe={wireframe} />
+      </mesh>
+      {noseGeom && (
+        <mesh geometry={noseGeom} position={nosePos}>
+          <meshStandardMaterial color="gray" side={THREE.DoubleSide} wireframe={wireframe} />
+        </mesh>
+      )}
+    </group>
   );
 }


### PR DESCRIPTION
## Summary
- add `noseLength` control and pass to `Fuselage`
- support optional nose geometry in `Fuselage`
- document new fuselage option

## Testing
- `npm run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687d5a73e320833087840d0316d69513