### PR TITLE
Add fuselage height control

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,4 @@ If you are developing a production application, we recommend using TypeScript wi
 - Fuselage tapers now form smooth curves rather than abrupt angles.
 - Adjustable tail height relative to the nose using the new "Tail Height" control.
 - Optional nose section that tapers in the opposite direction of the main fuselage.
+- Adjustable fuselage height independent of width.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -108,6 +108,7 @@ export default function App() {
   const fuselageParams = useControls('Fuselage', {
     length: { value: 200, min: 50, max: 600 },
     width: { value: 40, min: 10, max: 200 },
+    height: { value: 40, min: 10, max: 200 },
     taperH: { value: 0.8, min: 0.1, max: 1, step: 0.01, label: 'Horizontal Taper' },
     taperV: { value: 0.8, min: 0.1, max: 1, step: 0.01, label: 'Vertical Taper' },
     taperPosH: { value: 0, min: 0, max: 1, step: 0.01, label: 'Horizontal Taper Start' },

--- a/src/components/Aircraft.jsx
+++ b/src/components/Aircraft.jsx
@@ -17,6 +17,7 @@ export default function Aircraft({
       <Fuselage
         length={fuselageParams.length}
         width={fuselageParams.width}
+        height={fuselageParams.height}
         taperH={fuselageParams.taperH}
         taperV={fuselageParams.taperV}
         taperPosH={fuselageParams.taperPosH}

--- a/src/components/Fuselage.jsx
+++ b/src/components/Fuselage.jsx
@@ -21,6 +21,7 @@ function createRoundedRectShape(width, height, radius) {
 function createFuselageGeometry(
   length,
   width,
+  height,
   taperH,
   taperV,
   taperPosH,
@@ -50,7 +51,7 @@ function createFuselageGeometry(
     const vScale = scale(p, taperPosV, taperV, curveV);
     const shape = createRoundedRectShape(
       width * hScale,
-      width * vScale,
+      height * vScale,
       radius * Math.min(hScale, vScale),
     );
     return shape.getPoints(32);
@@ -98,6 +99,7 @@ function createFuselageGeometry(
 export default function Fuselage({
   length,
   width,
+  height,
   taperH,
   taperV,
   taperPosH,
@@ -114,6 +116,7 @@ export default function Fuselage({
       createFuselageGeometry(
         length,
         width,
+        height,
         taperH,
         taperV,
         taperPosH,
@@ -123,7 +126,7 @@ export default function Fuselage({
         curveV,
         tailHeight,
       ),
-    [length, width, taperH, taperV, taperPosH, taperPosV, cornerDiameter, curveH, curveV, tailHeight]
+    [length, width, height, taperH, taperV, taperPosH, taperPosV, cornerDiameter, curveH, curveV, tailHeight]
   );
 
   const noseGeom = useMemo(() => {
@@ -131,6 +134,7 @@ export default function Fuselage({
     return createFuselageGeometry(
       noseLength,
       width * taperH,
+      height * taperV,
       1 / taperH,
       1 / taperV,
       taperPosH,
@@ -139,7 +143,7 @@ export default function Fuselage({
       curveH,
       curveV,
     );
-  }, [noseLength, width, taperH, taperV, taperPosH, taperPosV, cornerDiameter, curveH, curveV]);
+  }, [noseLength, width, height, taperH, taperV, taperPosH, taperPosV, cornerDiameter, curveH, curveV]);
 
   const nosePos = useMemo(() => [-length / 2 - noseLength / 2, 0, 0], [length, noseLength]);
 


### PR DESCRIPTION
## Summary
- add `height` parameter to fuselage controls
- allow Fuselage component and geometry builder to use height value
- pass fuselage height through Aircraft component
- document fuselage height feature

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d63ad24c08330ac32f5c6f6342652