### PR TITLE
Add ellipse or square fuselage option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@ If you are developing a production application, we recommend using TypeScript wi
 - Adjustable tail height relative to the nose using the new "Tail Height" control.
 - Fuselage ends are automatically beveled and closed.
 - Adjustable fuselage height independent of width.
+- Option to choose an elliptical or square fuselage shape.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -113,6 +113,7 @@ export default function App() {
   });
 
   const fuselageParams = useControls('Fuselage', {
+    shape: { value: 'Square', options: ['Square', 'Ellipse'], label: 'Fuselage Shape' },
     length: { value: 200, min: 50, max: 600 },
     width: { value: 40, min: 10, max: 200 },
     height: { value: 40, min: 10, max: 200 },
@@ -120,7 +121,13 @@ export default function App() {
     taperV: { value: 0.8, min: 0.1, max: 1, step: 0.01, label: 'Vertical Taper' },
     taperPosH: { value: 0, min: 0, max: 1, step: 0.01, label: 'Horizontal Taper Start' },
     taperPosV: { value: 0, min: 0, max: 1, step: 0.01, label: 'Vertical Taper Start' },
-    cornerDiameter: { value: 10, min: 0, max: 50, label: 'Corner Diameter' },
+    cornerDiameter: {
+      value: 10,
+      min: 0,
+      max: 50,
+      label: 'Corner Diameter',
+      render: (get) => get('Fuselage.shape') === 'Square',
+    },
     curveH: { value: 1, min: 0.1, max: 5, step: 0.1, label: 'Horizontal Taper Curve' },
     curveV: { value: 1, min: 0.1, max: 5, step: 0.1, label: 'Vertical Taper Curve' },
     tailHeight: { value: 0, min: -100, max: 100, step: 1, label: 'Tail Height' },

--- a/src/components/Aircraft.jsx
+++ b/src/components/Aircraft.jsx
@@ -18,6 +18,7 @@ export default function Aircraft({
         length={fuselageParams.length}
         width={fuselageParams.width}
         height={fuselageParams.height}
+        shape={fuselageParams.shape}
         taperH={fuselageParams.taperH}
         taperV={fuselageParams.taperV}
         taperPosH={fuselageParams.taperPosH}

--- a/src/components/Fuselage.jsx
+++ b/src/components/Fuselage.jsx
@@ -18,6 +18,12 @@ function createRoundedRectShape(width, height, radius) {
   return shape;
 }
 
+function createEllipseShape(width, height) {
+  const shape = new THREE.Shape();
+  shape.absellipse(0, 0, width / 2, height / 2, 0, Math.PI * 2, false, 0);
+  return shape;
+}
+
 function createFuselageGeometry(
   length,
   width,
@@ -30,6 +36,7 @@ function createFuselageGeometry(
   curveH,
   curveV,
   tailHeight = 0,
+  shape = 'Square',
 ) {
   const radius = cornerDiameter / 2;
 
@@ -49,13 +56,17 @@ function createFuselageGeometry(
   const pointArrays = positions.map((p) => {
     const hScale = scale(p, taperPosH, taperH, curveH);
     const vScale = scale(p, taperPosV, taperV, curveV);
-    const shape = createRoundedRectShape(
-      width * hScale,
-      width * vScale,
-      height * vScale,
-      radius * Math.min(hScale, vScale),
-    );
-    return shape.getPoints(32);
+    let cross;
+    if (shape === 'Ellipse') {
+      cross = createEllipseShape(width * hScale, height * vScale);
+    } else {
+      cross = createRoundedRectShape(
+        width * hScale,
+        height * vScale,
+        radius * Math.min(hScale, vScale),
+      );
+    }
+    return cross.getPoints(32);
   });
 
   const vertices = [];
@@ -141,6 +152,7 @@ export default function Fuselage({
   curveH = 1,
   curveV = 1,
   tailHeight = 0,
+  shape = 'Square',
   wireframe = false,
 }) {
   const geom = useMemo(
@@ -157,6 +169,7 @@ export default function Fuselage({
         curveH,
         curveV,
         tailHeight,
+        shape,
       ),
     [
       length,
@@ -170,6 +183,7 @@ export default function Fuselage({
       curveH,
       curveV,
       tailHeight,
+      shape,
     ]
   );
 


### PR DESCRIPTION
## Summary
- allow selecting fuselage shape (square or ellipse)
- adjust fuselage geometry creation to handle ellipse cross-section
- hide corner radius control when ellipse shape is selected
- document new fuselage shape option

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687dbc0f4d448330b70fe3f29ba358a2