### PR TITLE
Fix fuselage taper crash

### DIFF
--- a/src/components/Fuselage.jsx
+++ b/src/components/Fuselage.jsx
@@ -50,7 +50,8 @@ function createFuselageGeometry(
     if (p <= pos) return 1;
     const t = (p - pos) / (1 - pos);
     const curved = Math.pow(t, curve);
-    return 1 + curved * (taper - 1);
+    const s = 1 + curved * (taper - 1);
+    return Math.max(s, 0.001); // prevent zero scale which can crash geometry
   }
 
   const pointArrays = positions.map((p) => {


### PR DESCRIPTION
## Summary
- avoid zero scale when taper and tail height combine

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687dbe69882c83309a4237ec13e03b68