### PR TITLE
Add separate shape controls for fuselage halves

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -113,7 +113,8 @@ export default function App() {
   });
 
   const fuselageParams = useControls('Fuselage', {
-    shape: { value: 'Square', options: ['Square', 'Ellipse'], label: 'Fuselage Shape' },
+    topShape: { value: 'Square', options: ['Square', 'Ellipse'], label: 'Top Shape' },
+    bottomShape: { value: 'Square', options: ['Square', 'Ellipse'], label: 'Bottom Shape' },
     length: { value: 200, min: 50, max: 600 },
     width: { value: 40, min: 10, max: 200 },
     height: { value: 40, min: 10, max: 200 },
@@ -126,7 +127,9 @@ export default function App() {
       min: 0,
       max: 50,
       label: 'Corner Diameter',
-      render: (get) => get('Fuselage.shape') === 'Square',
+      render: (get) =>
+        get('Fuselage.topShape') === 'Square' ||
+        get('Fuselage.bottomShape') === 'Square',
     },
     curveH: { value: 1, min: 0.1, max: 5, step: 0.1, label: 'Horizontal Taper Curve' },
     curveV: { value: 1, min: 0.1, max: 5, step: 0.1, label: 'Vertical Taper Curve' },

--- a/src/components/Aircraft.jsx
+++ b/src/components/Aircraft.jsx
@@ -18,7 +18,8 @@ export default function Aircraft({
         length={fuselageParams.length}
         width={fuselageParams.width}
         height={fuselageParams.height}
-        shape={fuselageParams.shape}
+        topShape={fuselageParams.topShape}
+        bottomShape={fuselageParams.bottomShape}
         taperH={fuselageParams.taperH}
         taperV={fuselageParams.taperV}
         taperPosH={fuselageParams.taperPosH}

--- a/src/components/Fuselage.jsx
+++ b/src/components/Fuselage.jsx
@@ -18,6 +18,36 @@ function createRoundedRectShape(width, height, radius) {
   return shape;
 }
 
+function createTopBottomShape(width, height, radius, topShape, bottomShape) {
+  const halfW = width / 2;
+  const halfH = height / 2;
+  const r = Math.min(radius, halfW, halfH);
+  const shape = new THREE.Shape();
+  shape.moveTo(halfW, 0);
+
+  if (bottomShape === 'Ellipse') {
+    shape.absellipse(0, 0, halfW, halfH, 0, Math.PI, true, 0);
+  } else {
+    shape.lineTo(halfW, -halfH + r);
+    shape.quadraticCurveTo(halfW, -halfH, halfW - r, -halfH);
+    shape.lineTo(-halfW + r, -halfH);
+    shape.quadraticCurveTo(-halfW, -halfH, -halfW, -halfH + r);
+    shape.lineTo(-halfW, 0);
+  }
+
+  if (topShape === 'Ellipse') {
+    shape.absellipse(0, 0, halfW, halfH, Math.PI, Math.PI * 2, true, 0);
+  } else {
+    shape.lineTo(-halfW, halfH - r);
+    shape.quadraticCurveTo(-halfW, halfH, -halfW + r, halfH);
+    shape.lineTo(halfW - r, halfH);
+    shape.quadraticCurveTo(halfW, halfH, halfW, halfH - r);
+    shape.lineTo(halfW, 0);
+  }
+
+  return shape;
+}
+
 function createEllipseShape(width, height) {
   const shape = new THREE.Shape();
   shape.absellipse(0, 0, width / 2, height / 2, 0, Math.PI * 2, false, 0);
@@ -36,7 +66,8 @@ function createFuselageGeometry(
   curveH,
   curveV,
   tailHeight = 0,
-  shape = 'Square',
+  topShape = 'Square',
+  bottomShape = 'Square',
 ) {
   const radius = cornerDiameter / 2;
 
@@ -58,13 +89,21 @@ function createFuselageGeometry(
     const hScale = scale(p, taperPosH, taperH, curveH);
     const vScale = scale(p, taperPosV, taperV, curveV);
     let cross;
-    if (shape === 'Ellipse') {
+    if (topShape === 'Ellipse' && bottomShape === 'Ellipse') {
       cross = createEllipseShape(width * hScale, height * vScale);
-    } else {
+    } else if (topShape === 'Square' && bottomShape === 'Square') {
       cross = createRoundedRectShape(
         width * hScale,
         height * vScale,
         radius * Math.min(hScale, vScale),
+      );
+    } else {
+      cross = createTopBottomShape(
+        width * hScale,
+        height * vScale,
+        radius * Math.min(hScale, vScale),
+        topShape,
+        bottomShape,
       );
     }
     return cross.getPoints(32);
@@ -153,7 +192,8 @@ export default function Fuselage({
   curveH = 1,
   curveV = 1,
   tailHeight = 0,
-  shape = 'Square',
+  topShape = 'Square',
+  bottomShape = 'Square',
   wireframe = false,
 }) {
   const geom = useMemo(
@@ -170,7 +210,8 @@ export default function Fuselage({
         curveH,
         curveV,
         tailHeight,
-        shape,
+        topShape,
+        bottomShape,
       ),
     [
       length,
@@ -184,7 +225,8 @@ export default function Fuselage({
       curveH,
       curveV,
       tailHeight,
-      shape,
+      topShape,
+      bottomShape,
     ]
   );
 


### PR DESCRIPTION
## Summary
- support different shapes for the top and bottom of the fuselage
- wire Aircraft component to pass new shape settings
- expose "Top Shape" and "Bottom Shape" controls in the UI

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687dc6e93394833093533cf10943ab8d