### PR TITLE
Add nacelles on wing panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ If you are developing a production application, we recommend using TypeScript wi
 - Fuselage ends are automatically beveled and closed.
 - Adjustable fuselage height independent of width.
 - Option to choose an elliptical or square fuselage shape.
+- Optional nacelles can be added at the end of each wing panel.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -136,6 +136,16 @@ export default function App() {
     tailHeight: { value: 0, min: -100, max: 100, step: 1, label: 'Tail Height' },
   });
 
+  const {
+    showNacelles,
+    nacelleRadius,
+    nacelleLength,
+  } = useControls('Nacelles', {
+    showNacelles: false,
+    nacelleRadius: { value: 10, min: 1, max: 100, step: 1, label: 'Radius' },
+    nacelleLength: { value: 40, min: 10, max: 200, step: 1, label: 'Length' },
+  });
+
   const sections = [rootParams];
   if (enablePanel1) sections.push(panel1Params);
   if (enablePanel2) sections.push(panel2Params);
@@ -231,6 +241,9 @@ export default function App() {
             mirrored={mirrored}
             mountHeight={mountHeight}
             mountZ={mountZ}
+            showNacelles={showNacelles}
+            nacelleRadius={nacelleRadius}
+            nacelleLength={nacelleLength}
             fuselageParams={fuselageParams}
           />
           <OrbitControls ref={controlsRef} />
@@ -253,6 +266,9 @@ export default function App() {
               mirrored={mirrored}
               mountHeight={mountHeight}
               mountZ={mountZ}
+              showNacelles={showNacelles}
+              nacelleRadius={nacelleRadius}
+              nacelleLength={nacelleLength}
               fuselageParams={fuselageParams}
               wireframe
             />
@@ -264,6 +280,9 @@ export default function App() {
               mirrored={mirrored}
               mountHeight={mountHeight}
               mountZ={mountZ}
+              showNacelles={showNacelles}
+              nacelleRadius={nacelleRadius}
+              nacelleLength={nacelleLength}
               fuselageParams={fuselageParams}
               wireframe
             />

--- a/src/components/Aircraft.jsx
+++ b/src/components/Aircraft.jsx
@@ -11,6 +11,9 @@ export default function Aircraft({
   fuselageParams,
   groupRef,
   wireframe = false,
+  showNacelles = false,
+  nacelleRadius = 10,
+  nacelleLength = 40,
 }) {
   return (
     <group ref={groupRef}>
@@ -36,6 +39,9 @@ export default function Aircraft({
         mirrored={mirrored}
         mountHeight={mountHeight}
         mountZ={mountZ}
+        showNacelles={showNacelles}
+        nacelleRadius={nacelleRadius}
+        nacelleLength={nacelleLength}
         wireframe={wireframe}
       />
     </group>

--- a/src/components/Nacelle.jsx
+++ b/src/components/Nacelle.jsx
@@ -1,0 +1,11 @@
+import React, { useMemo } from 'react';
+import * as THREE from 'three';
+
+export default function Nacelle({ length = 40, radius = 10, position = [0, 0, 0], wireframe = false }) {
+  const geom = useMemo(() => new THREE.CylinderGeometry(radius, radius, length, 16), [radius, length]);
+  return (
+    <mesh geometry={geom} position={position} rotation={[Math.PI / 2, 0, 0]}>
+      <meshStandardMaterial color="silver" side={THREE.DoubleSide} wireframe={wireframe} />
+    </mesh>
+  );
+}


### PR DESCRIPTION
## Summary
- create `Nacelle` component
- compute nacelle positions in `Wing` and render optional nacelles
- pass nacelle options through `Aircraft` and `App`
- expose new Leva controls and document feature

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687dca57e0cc8330b9a9b2d79835f728