### PR TITLE
Add design workflow scaffolding

### DIFF
--- a/src/design/AirfoilStep.jsx
+++ b/src/design/AirfoilStep.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function AirfoilStep() {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h2>Airfoils</h2>
+      <p>Configure airfoil sections.</p>
+    </div>
+  );
+}

--- a/src/design/BuildStep.jsx
+++ b/src/design/BuildStep.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function BuildStep() {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h2>Build</h2>
+      <p>Edit aircraft geometry and parameters.</p>
+    </div>
+  );
+}

--- a/src/design/DesignFlow.jsx
+++ b/src/design/DesignFlow.jsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import TemplateStep from './TemplateStep.jsx';
+import BuildStep from './BuildStep.jsx';
+import AirfoilStep from './AirfoilStep.jsx';
+import ExportStep from './ExportStep.jsx';
+
+const steps = [
+  { label: 'Templates', component: <TemplateStep /> },
+  { label: 'Build', component: <BuildStep /> },
+  { label: 'Airfoils', component: <AirfoilStep /> },
+  { label: 'Export', component: <ExportStep /> },
+];
+
+export default function DesignFlow() {
+  const [current, setCurrent] = useState(0);
+
+  return (
+    <div style={{ display: 'flex', height: '100%' }}>
+      <nav
+        style={{
+          width: '200px',
+          background: '#222',
+          color: '#fff',
+          padding: '1rem',
+        }}
+      >
+        <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+          {steps.map((step, index) => (
+            <li key={step.label} style={{ marginBottom: '0.5rem' }}>
+              <button
+                type="button"
+                onClick={() => setCurrent(index)}
+                style={{
+                  width: '100%',
+                  padding: '0.5rem 1rem',
+                  background: 'transparent',
+                  color: 'inherit',
+                  border: 'none',
+                  textAlign: 'left',
+                  cursor: 'pointer',
+                  borderLeft:
+                    current === index ? '4px solid #646cff' : '4px solid transparent',
+                }}
+              >
+                {step.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </nav>
+      <div style={{ flex: 1 }}>{steps[current].component}</div>
+    </div>
+  );
+}

--- a/src/design/ExportStep.jsx
+++ b/src/design/ExportStep.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function ExportStep() {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h2>Export</h2>
+      <p>Prepare layout for fabrication (SVG, DXF).</p>
+    </div>
+  );
+}

--- a/src/design/TemplateStep.jsx
+++ b/src/design/TemplateStep.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function TemplateStep() {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h2>Templates</h2>
+      <p>Choose a predefined aircraft layout.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- scaffold multi-step design flow under `src/design/`
- each step is a placeholder component
- `DesignFlow` provides vertical navigation and renders one step at a time

## Testing
- `npm run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687e43c2c868833084915e037378ad7e