### PR TITLE
Add design flow component and step placeholders

### DIFF
--- a/src/components/AirfoilStep.jsx
+++ b/src/components/AirfoilStep.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function AirfoilStep() {
+  return (
+    <div>
+      <h2>Airfoils</h2>
+      <p>Configure the airfoil sections used on the aircraft.</p>
+    </div>
+  );
+}

--- a/src/components/BuildStep.jsx
+++ b/src/components/BuildStep.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function BuildStep() {
+  return (
+    <div>
+      <h2>Build</h2>
+      <p>Edit geometry and design parameters for your aircraft.</p>
+    </div>
+  );
+}

--- a/src/components/DesignFlow.jsx
+++ b/src/components/DesignFlow.jsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+import TemplateStep from './TemplateStep.jsx';
+import BuildStep from './BuildStep.jsx';
+import AirfoilStep from './AirfoilStep.jsx';
+import ExportStep from './ExportStep.jsx';
+
+export default function DesignFlow() {
+  const [currentStep, setCurrentStep] = useState(0);
+
+  const steps = [
+    { title: 'Templates', component: <TemplateStep /> },
+    { title: 'Build', component: <BuildStep /> },
+    { title: 'Airfoils', component: <AirfoilStep /> },
+    { title: 'Export', component: <ExportStep /> },
+  ];
+
+  return (
+    <div style={{ display: 'flex', height: '100vh' }}>
+      <aside
+        style={{
+          width: '200px',
+          borderRight: '1px solid #ccc',
+          padding: '1rem',
+          boxSizing: 'border-box',
+          background: '#f8f8f8',
+        }}
+      >
+        <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+          {steps.map((step, index) => (
+            <li
+              key={step.title}
+              onClick={() => setCurrentStep(index)}
+              style={{
+                padding: '0.5rem',
+                marginBottom: '0.25rem',
+                cursor: 'pointer',
+                background: index === currentStep ? '#eaeaea' : 'transparent',
+                fontWeight: index === currentStep ? 'bold' : 'normal',
+              }}
+            >
+              {index + 1}. {step.title}
+            </li>
+          ))}
+        </ul>
+      </aside>
+      <main style={{ flex: 1, padding: '1rem', overflow: 'auto' }}>
+        {steps[currentStep].component}
+      </main>
+    </div>
+  );
+}

--- a/src/components/ExportStep.jsx
+++ b/src/components/ExportStep.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function ExportStep() {
+  return (
+    <div>
+      <h2>Export</h2>
+      <p>Prepare and export your design for fabrication.</p>
+    </div>
+  );
+}

--- a/src/components/TemplateStep.jsx
+++ b/src/components/TemplateStep.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function TemplateStep() {
+  return (
+    <div>
+      <h2>Templates</h2>
+      <p>Select a predefined aircraft layout to start your design.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- scaffold multi-step design flow component with sidebar navigation
- add placeholder step components for Templates, Build, Airfoils and Export screens

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687e43c2c868833084915e037378ad7e