### PR TITLE
Add basic multi-step design flow UI

### DIFF
--- a/src/components/AirfoilStep.jsx
+++ b/src/components/AirfoilStep.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function AirfoilStep() {
+  return (
+    <div>
+      <h2>Airfoils</h2>
+      <p>Configure the airfoil sections for your aircraft.</p>
+    </div>
+  );
+}

--- a/src/components/BuildStep.jsx
+++ b/src/components/BuildStep.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function BuildStep() {
+  return (
+    <div>
+      <h2>Build</h2>
+      <p>Edit the aircraft geometry and parameters.</p>
+    </div>
+  );
+}

--- a/src/components/DesignFlow.jsx
+++ b/src/components/DesignFlow.jsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import TemplateStep from './TemplateStep';
+import BuildStep from './BuildStep';
+import AirfoilStep from './AirfoilStep';
+import ExportStep from './ExportStep';
+
+const stepComponents = [
+  { label: 'Templates', component: TemplateStep },
+  { label: 'Build', component: BuildStep },
+  { label: 'Airfoils', component: AirfoilStep },
+  { label: 'Export', component: ExportStep },
+];
+
+export default function DesignFlow() {
+  const [currentStep, setCurrentStep] = useState(0);
+  const CurrentComponent = stepComponents[currentStep].component;
+
+  return (
+    <div style={{ display: 'flex', height: '100vh' }}>
+      <aside
+        style={{
+          width: '200px',
+          background: '#222',
+          color: '#fff',
+          padding: '1rem',
+        }}
+      >
+        <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+          {stepComponents.map((step, index) => (
+            <li key={step.label} style={{ marginBottom: '0.5rem' }}>
+              <button
+                type="button"
+                onClick={() => setCurrentStep(index)}
+                style={{
+                  width: '100%',
+                  padding: '0.5rem 1rem',
+                  background: 'none',
+                  border: 'none',
+                  color: index === currentStep ? '#61dafb' : '#fff',
+                  cursor: 'pointer',
+                  textAlign: 'left',
+                }}
+              >
+                {step.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </aside>
+      <main style={{ flex: 1, padding: '1rem' }}>
+        <CurrentComponent />
+      </main>
+    </div>
+  );
+}

--- a/src/components/ExportStep.jsx
+++ b/src/components/ExportStep.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function ExportStep() {
+  return (
+    <div>
+      <h2>Export</h2>
+      <p>Prepare your layout for fabrication in SVG or DXF formats.</p>
+    </div>
+  );
+}

--- a/src/components/TemplateStep.jsx
+++ b/src/components/TemplateStep.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function TemplateStep() {
+  return (
+    <div>
+      <h2>Templates</h2>
+      <p>Select a predefined aircraft layout to start your design.</p>
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,10 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import App from './App.jsx'
+import DesignFlow from './components/DesignFlow.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <DesignFlow />
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- add placeholder step components
- create `DesignFlow` with sidebar navigation
- load `DesignFlow` as the root component

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687e43c2c868833084915e037378ad7e