### PR TITLE
Add basic design flow navigation

### DIFF
--- a/src/components/DesignFlow.jsx
+++ b/src/components/DesignFlow.jsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import TemplateStep from './steps/TemplateStep.jsx';
+import BuildStep from './steps/BuildStep.jsx';
+import AirfoilStep from './steps/AirfoilStep.jsx';
+import ExportStep from './steps/ExportStep.jsx';
+
+const stepList = [
+  { id: 0, label: 'Templates', component: <TemplateStep /> },
+  { id: 1, label: 'Build', component: <BuildStep /> },
+  { id: 2, label: 'Airfoils', component: <AirfoilStep /> },
+  { id: 3, label: 'Export', component: <ExportStep /> },
+];
+
+export default function DesignFlow() {
+  const [current, setCurrent] = useState(0);
+
+  return (
+    <div style={{ display: 'flex', height: '100vh', fontFamily: 'sans-serif' }}>
+      <nav
+        style={{
+          width: '200px',
+          borderRight: '1px solid #ddd',
+          padding: '20px 0',
+        }}
+      >
+        {stepList.map((step) => (
+          <div
+            key={step.id}
+            onClick={() => setCurrent(step.id)}
+            style={{
+              padding: '10px 20px',
+              cursor: 'pointer',
+              background: current === step.id ? '#f0f0f0' : 'transparent',
+              fontWeight: current === step.id ? 'bold' : 'normal',
+            }}
+          >
+            {step.label}
+          </div>
+        ))}
+      </nav>
+      <main style={{ flex: 1 }}>{stepList[current].component}</main>
+    </div>
+  );
+}

--- a/src/components/steps/AirfoilStep.jsx
+++ b/src/components/steps/AirfoilStep.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function AirfoilStep() {
+  return (
+    <div style={{ padding: '20px' }}>
+      <h2>Airfoils</h2>
+      <p>Configure airfoil sections and properties here.</p>
+    </div>
+  );
+}

--- a/src/components/steps/BuildStep.jsx
+++ b/src/components/steps/BuildStep.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function BuildStep() {
+  return (
+    <div style={{ padding: '20px' }}>
+      <h2>Build</h2>
+      <p>Edit aircraft geometry and parameters in this step.</p>
+    </div>
+  );
+}

--- a/src/components/steps/ExportStep.jsx
+++ b/src/components/steps/ExportStep.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function ExportStep() {
+  return (
+    <div style={{ padding: '20px' }}>
+      <h2>Export</h2>
+      <p>Prepare your layout for fabrication in SVG or DXF format.</p>
+    </div>
+  );
+}

--- a/src/components/steps/TemplateStep.jsx
+++ b/src/components/steps/TemplateStep.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function TemplateStep() {
+  return (
+    <div style={{ padding: '20px' }}>
+      <h2>Templates</h2>
+      <p>Select a predefined aircraft layout to start your design.</p>
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,10 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import App from './App.jsx'
+import DesignFlow from './components/DesignFlow.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <DesignFlow />
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- add placeholder step components for design wizard
- implement `DesignFlow` component to manage step navigation
- render `DesignFlow` from `main.jsx`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e43c2c868833084915e037378ad7e