### PR TITLE
Add independent top/bottom fuselage taper controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ If you are developing a production application, we recommend using TypeScript wi
 ## Features
 - Adjustable wing mount position along the fuselage using the new "Mount Position" control.
 - Independent vertical and horizontal fuselage taper with adjustable start positions.
+- Independent top and bottom fuselage tapers.
 - Curvature controls for both horizontal and vertical fuselage tapers.
 - Fuselage tapers now form smooth curves rather than abrupt angles.
 - Adjustable tail height relative to the nose using the new "Tail Height" control.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -119,7 +119,8 @@ export default function App({ showAirfoilControls = false } = {}) {
     width: { value: 40, min: 10, max: 200 },
     height: { value: 40, min: 10, max: 200 },
     taperH: { value: 0.8, min: 0.1, max: 1, step: 0.01, label: 'Horizontal Taper' },
-    taperV: { value: 0.8, min: 0.1, max: 1, step: 0.01, label: 'Vertical Taper' },
+    taperTop: { value: 0.8, min: 0.1, max: 1, step: 0.01, label: 'Top Taper' },
+    taperBottom: { value: 0.8, min: 0.1, max: 1, step: 0.01, label: 'Bottom Taper' },
     taperPosH: { value: 0, min: 0, max: 1, step: 0.01, label: 'Horizontal Taper Start' },
     taperPosV: { value: 0, min: 0, max: 1, step: 0.01, label: 'Vertical Taper Start' },
     cornerDiameter: {

--- a/src/components/Aircraft.jsx
+++ b/src/components/Aircraft.jsx
@@ -24,7 +24,8 @@ export default function Aircraft({
         topShape={fuselageParams.topShape}
         bottomShape={fuselageParams.bottomShape}
         taperH={fuselageParams.taperH}
-        taperV={fuselageParams.taperV}
+        taperTop={fuselageParams.taperTop}
+        taperBottom={fuselageParams.taperBottom}
         taperPosH={fuselageParams.taperPosH}
         taperPosV={fuselageParams.taperPosV}
         cornerDiameter={fuselageParams.cornerDiameter}

--- a/src/components/Fuselage.jsx
+++ b/src/components/Fuselage.jsx
@@ -59,7 +59,8 @@ function createFuselageGeometry(
   width,
   height,
   taperH,
-  taperV,
+  taperTop,
+  taperBottom,
   taperPosH,
   taperPosV,
   cornerDiameter,
@@ -93,26 +94,33 @@ function createFuselageGeometry(
 
   const pointArrays = positions.map((p) => {
     const hScale = scale(p, taperPosH, taperH, curveH);
-    const vScale = scale(p, taperPosV, taperV, curveV);
+    const topScale = scale(p, taperPosV, taperTop, curveV);
+    const bottomScale = scale(p, taperPosV, taperBottom, curveV);
+    const avgScale = (topScale + bottomScale) / 2;
     let cross;
     if (topShape === 'Ellipse' && bottomShape === 'Ellipse') {
-      cross = createEllipseShape(width * hScale, height * vScale);
+      cross = createEllipseShape(width * hScale, height);
     } else if (topShape === 'Square' && bottomShape === 'Square') {
       cross = createRoundedRectShape(
         width * hScale,
-        height * vScale,
-        radius * Math.min(hScale, vScale),
+        height,
+        radius * Math.min(hScale, avgScale),
       );
     } else {
       cross = createTopBottomShape(
         width * hScale,
-        height * vScale,
-        radius * Math.min(hScale, vScale),
+        height,
+        radius * Math.min(hScale, avgScale),
         topShape,
         bottomShape,
       );
     }
-    return cross.getPoints(32);
+    const pts = cross.getPoints(32).map((pt) =>
+      pt.y >= 0
+        ? new THREE.Vector2(pt.x, pt.y * topScale)
+        : new THREE.Vector2(pt.x, pt.y * bottomScale),
+    );
+    return pts;
   });
 
   const sections = [];
@@ -247,7 +255,8 @@ export default function Fuselage({
   width,
   height,
   taperH,
-  taperV,
+  taperTop,
+  taperBottom,
   taperPosH,
   taperPosV,
   cornerDiameter,
@@ -271,7 +280,8 @@ export default function Fuselage({
         width,
         height,
         taperH,
-        taperV,
+        taperTop,
+        taperBottom,
         taperPosH,
         taperPosV,
         cornerDiameter,
@@ -292,7 +302,8 @@ export default function Fuselage({
       width,
       height,
       taperH,
-      taperV,
+      taperTop,
+      taperBottom,
       taperPosH,
       taperPosV,
       cornerDiameter,


### PR DESCRIPTION
## Summary
- support separate top and bottom fuselage taper parameters
- expose new controls in the UI
- document feature in README

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688075d91c4c83308674f82e9586fedd