### PR TITLE
Add flexible rudder and optional fuselage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,6 @@ If you are developing a production application, we recommend using TypeScript wi
 - Option to choose an elliptical or square fuselage shape.
 - Optional nacelles can be added at the end of each wing panel.
 - A rudder can be added to the rear of the fuselage.
+- The rudder now supports separate root and tip lengths as well as
+  independent front and back curve controls.
+- The fuselage can be hidden entirely if desired.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -113,6 +113,7 @@ export default function App({ showAirfoilControls = false } = {}) {
   });
 
   const fuselageParams = useControls('Fuselage', {
+    showFuselage: { value: true, label: 'Show Fuselage' },
     topShape: { value: 'Square', options: ['Square', 'Ellipse'], label: 'Top Shape' },
     bottomShape: { value: 'Square', options: ['Square', 'Ellipse'], label: 'Bottom Shape' },
     length: { value: 200, min: 50, max: 600 },
@@ -156,13 +157,19 @@ export default function App({ showAirfoilControls = false } = {}) {
   const {
     showRudder,
     rudderHeight,
-    rudderChord,
+    rootChord,
+    tipChord,
     rudderThickness,
+    frontCurve,
+    backCurve,
   } = useControls('Rudder', {
     showRudder: false,
     rudderHeight: { value: 40, min: 10, max: 100, step: 1, label: 'Height' },
-    rudderChord: { value: 30, min: 10, max: 100, step: 1, label: 'Chord' },
+    rootChord: { value: 30, min: 10, max: 100, step: 1, label: 'Root Chord' },
+    tipChord: { value: 0, min: 0, max: 100, step: 1, label: 'Tip Chord' },
     rudderThickness: { value: 2, min: 1, max: 10, step: 0.5, label: 'Thickness' },
+    frontCurve: { value: 1, min: 0.1, max: 5, step: 0.1, label: 'Front Curve' },
+    backCurve: { value: 1, min: 0.1, max: 5, step: 0.1, label: 'Back Curve' },
   });
 
   const sections = [rootParams];
@@ -274,8 +281,12 @@ export default function App({ showAirfoilControls = false } = {}) {
                 nacelleLength={nacelleLength}
                 showRudder={showRudder}
                 rudderHeight={rudderHeight}
-                rudderChord={rudderChord}
+                rootChord={rootChord}
+                tipChord={tipChord}
                 rudderThickness={rudderThickness}
+                frontCurve={frontCurve}
+                backCurve={backCurve}
+                showFuselage={fuselageParams.showFuselage}
                 fuselageParams={fuselageParams}
               />
               <OrbitControls ref={controlsRef} />
@@ -303,8 +314,12 @@ export default function App({ showAirfoilControls = false } = {}) {
                   nacelleLength={nacelleLength}
                   showRudder={showRudder}
                   rudderHeight={rudderHeight}
-                  rudderChord={rudderChord}
+                  rootChord={rootChord}
+                  tipChord={tipChord}
                   rudderThickness={rudderThickness}
+                  frontCurve={frontCurve}
+                  backCurve={backCurve}
+                  showFuselage={fuselageParams.showFuselage}
                   fuselageParams={fuselageParams}
                   wireframe
                 />
@@ -321,8 +336,12 @@ export default function App({ showAirfoilControls = false } = {}) {
                   nacelleLength={nacelleLength}
                   showRudder={showRudder}
                   rudderHeight={rudderHeight}
-                  rudderChord={rudderChord}
+                  rootChord={rootChord}
+                  tipChord={tipChord}
                   rudderThickness={rudderThickness}
+                  frontCurve={frontCurve}
+                  backCurve={backCurve}
+                  showFuselage={fuselageParams.showFuselage}
                   fuselageParams={fuselageParams}
                   wireframe
                 />

--- a/src/components/Aircraft.jsx
+++ b/src/components/Aircraft.jsx
@@ -12,44 +12,53 @@ export default function Aircraft({
   fuselageParams,
   groupRef,
   wireframe = false,
+  showFuselage = true,
   showNacelles = false,
   nacelleRadius = 10,
   nacelleLength = 40,
   showRudder = false,
   rudderHeight = 40,
-  rudderChord = 30,
+  rootChord = 30,
+  tipChord = 0,
   rudderThickness = 2,
+  frontCurve = 1,
+  backCurve = 1,
 }) {
   return (
     <group ref={groupRef}>
-      <Fuselage
-        length={fuselageParams.length}
-        width={fuselageParams.width}
-        height={fuselageParams.height}
-        topShape={fuselageParams.topShape}
-        bottomShape={fuselageParams.bottomShape}
-        taperH={fuselageParams.taperH}
-        taperTop={fuselageParams.taperTop}
-        taperBottom={fuselageParams.taperBottom}
-        taperPosH={fuselageParams.taperPosH}
-        taperPosV={fuselageParams.taperPosV}
-        cornerDiameter={fuselageParams.cornerDiameter}
-        curveH={fuselageParams.curveH}
-        curveV={fuselageParams.curveV}
-        tailHeight={fuselageParams.tailHeight}
-        wireframe={wireframe}
-        closeNose={fuselageParams.closeNose}
-        closeTail={fuselageParams.closeTail}
-        nosecapLength={fuselageParams.nosecapLength}
-        nosecapSharpness={fuselageParams.nosecapSharpness}
-        tailcapLength={fuselageParams.nosecapLength}
-        tailcapSharpness={fuselageParams.nosecapSharpness}
-      />
+      {showFuselage && (
+        <Fuselage
+          length={fuselageParams.length}
+          width={fuselageParams.width}
+          height={fuselageParams.height}
+          topShape={fuselageParams.topShape}
+          bottomShape={fuselageParams.bottomShape}
+          taperH={fuselageParams.taperH}
+          taperTop={fuselageParams.taperTop}
+          taperBottom={fuselageParams.taperBottom}
+          taperPosH={fuselageParams.taperPosH}
+          taperPosV={fuselageParams.taperPosV}
+          cornerDiameter={fuselageParams.cornerDiameter}
+          curveH={fuselageParams.curveH}
+          curveV={fuselageParams.curveV}
+          tailHeight={fuselageParams.tailHeight}
+          wireframe={wireframe}
+          closeNose={fuselageParams.closeNose}
+          closeTail={fuselageParams.closeTail}
+          nosecapLength={fuselageParams.nosecapLength}
+          nosecapSharpness={fuselageParams.nosecapSharpness}
+          tailcapLength={fuselageParams.nosecapLength}
+          tailcapSharpness={fuselageParams.nosecapSharpness}
+        />
+      )}
       {showRudder && (
         <Rudder
           height={rudderHeight}
-          chord={rudderChord}
+          rootChord={rootChord}
+          tipChord={tipChord}
           thickness={rudderThickness}
+          frontCurve={frontCurve}
+          backCurve={backCurve}
           wireframe={wireframe}
           position={[
             0,

--- a/src/components/Rudder.jsx
+++ b/src/components/Rudder.jsx
@@ -1,17 +1,39 @@
 import React, { useMemo } from 'react';
 import * as THREE from 'three';
 
-export default function Rudder({ height = 40, chord = 30, thickness = 2, wireframe = false, position = [0,0,0] }) {
+export default function Rudder({
+  height = 40,
+  rootChord = 30,
+  tipChord = 0,
+  thickness = 2,
+  frontCurve = 1,
+  backCurve = 1,
+  wireframe = false,
+  position = [0, 0, 0],
+}) {
   const geom = useMemo(() => {
     const shape = new THREE.Shape();
-    shape.moveTo(0, 0);
-    shape.lineTo(chord, 0);
-    shape.lineTo(0, height);
+    const segments = 20;
+
+    const backX = (t) => rootChord + (tipChord - rootChord) * Math.pow(t, backCurve);
+    const frontX = (t) => -(rootChord - tipChord) * Math.pow(t, frontCurve);
+
+    shape.moveTo(frontX(0), 0);
+    shape.lineTo(backX(0), 0);
+    for (let i = 1; i <= segments; i++) {
+      const t = i / segments;
+      shape.lineTo(backX(t), height * t);
+    }
+    for (let i = segments; i >= 0; i--) {
+      const t = i / segments;
+      shape.lineTo(frontX(t), height * t);
+    }
     shape.closePath();
+
     const g = new THREE.ExtrudeGeometry(shape, { depth: thickness, bevelEnabled: false });
     g.rotateY(Math.PI / 2);
     return g;
-  }, [height, chord, thickness]);
+  }, [height, rootChord, tipChord, thickness, frontCurve, backCurve]);
 
   return (
     <mesh geometry={geom} position={position}>


### PR DESCRIPTION
## Summary
- add `showFuselage` option to hide fuselage
- support root/tip chord and front/back curve in rudder
- expose new rudder controls in the UI
- document new features

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688245a485b48330ba38564376faf5db