### PR TITLE
Fix rudder corner easing and swap curve controls

### DIFF
--- a/src/components/Aircraft.jsx
+++ b/src/components/Aircraft.jsx
@@ -60,8 +60,8 @@ export default function Aircraft({
           rootChord={rootChord}
           tipChord={tipChord}
           thickness={rudderThickness}
-          frontCurve={frontCurve}
-          backCurve={backCurve}
+          frontCurve={backCurve}
+          backCurve={frontCurve}
           frontRadius={frontRadius}
           backRadius={backRadius}
           offset={rudderOffset}

--- a/src/components/Rudder.jsx
+++ b/src/components/Rudder.jsx
@@ -27,8 +27,12 @@ export default function Rudder({
 
     function addCorner(cx, cy, radius, startA, endA, curve) {
       for (let i = 1; i <= cornerSegments; i++) {
-        const t = Math.pow(i / cornerSegments, curve);
-        const angle = startA + (endA - startA) * t;
+        const t = i / cornerSegments;
+        const eased =
+          t < 0.5
+            ? 0.5 * Math.pow(2 * t, curve)
+            : 1 - 0.5 * Math.pow(2 * (1 - t), curve);
+        const angle = startA + (endA - startA) * eased;
         shape.lineTo(cx + Math.cos(angle) * radius, cy + Math.sin(angle) * radius);
       }
     }


### PR DESCRIPTION
## Summary
- smooth the rudder corner arcs with an ease-in/out curve
- swap front/back curve props when creating the rudder

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688268928784833094bb922b21564b2a