### PR TITLE
Add elevator corner radius controls

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -188,6 +188,8 @@ export default function App({ showAirfoilControls = false } = {}) {
     elevatorSweep,
     elevatorLeadCurve,
     elevatorTrailCurve,
+    elevatorFrontRadius,
+    elevatorBackRadius,
   } = useControls('Elevator', {
     showElevator: false,
     elevatorType: { value: 'Flat', options: ['Flat', 'V'], label: 'Type' },
@@ -198,6 +200,8 @@ export default function App({ showAirfoilControls = false } = {}) {
     elevatorSweep: { value: 0, min: -50, max: 50, step: 1, label: 'Sweep' },
     elevatorLeadCurve: { value: 1, min: 0.1, max: 5, step: 0.1, label: 'Leading Edge Curve' },
     elevatorTrailCurve: { value: 1, min: 0.1, max: 5, step: 0.1, label: 'Trailing Edge Curve' },
+    elevatorFrontRadius: { value: 0, min: 0, max: 50, step: 1, label: 'Front Radius' },
+    elevatorBackRadius: { value: 0, min: 0, max: 50, step: 1, label: 'Back Radius' },
   });
 
   const sections = [rootParams];
@@ -326,6 +330,8 @@ export default function App({ showAirfoilControls = false } = {}) {
                 elevatorSweep={elevatorSweep}
                 elevatorLeadCurve={elevatorLeadCurve}
                 elevatorTrailCurve={elevatorTrailCurve}
+                elevatorFrontRadius={elevatorFrontRadius}
+                elevatorBackRadius={elevatorBackRadius}
                 showFuselage={fuselageParams.showFuselage}
                 fuselageParams={fuselageParams}
               />
@@ -371,6 +377,8 @@ export default function App({ showAirfoilControls = false } = {}) {
                 elevatorSweep={elevatorSweep}
                 elevatorLeadCurve={elevatorLeadCurve}
                 elevatorTrailCurve={elevatorTrailCurve}
+                elevatorFrontRadius={elevatorFrontRadius}
+                elevatorBackRadius={elevatorBackRadius}
                  showFuselage={fuselageParams.showFuselage}
                  fuselageParams={fuselageParams}
                  wireframe
@@ -405,6 +413,8 @@ export default function App({ showAirfoilControls = false } = {}) {
                 elevatorSweep={elevatorSweep}
                 elevatorLeadCurve={elevatorLeadCurve}
                 elevatorTrailCurve={elevatorTrailCurve}
+                elevatorFrontRadius={elevatorFrontRadius}
+                elevatorBackRadius={elevatorBackRadius}
                  showFuselage={fuselageParams.showFuselage}
                  fuselageParams={fuselageParams}
                  wireframe

--- a/src/components/Aircraft.jsx
+++ b/src/components/Aircraft.jsx
@@ -36,6 +36,8 @@ export default function Aircraft({
   elevatorSweep = 0,
   elevatorLeadCurve = 1,
   elevatorTrailCurve = 1,
+  elevatorFrontRadius = 0,
+  elevatorBackRadius = 0,
 }) {
   return (
     <group ref={groupRef}>
@@ -93,6 +95,8 @@ export default function Aircraft({
           sweep={elevatorSweep}
           leadCurve={elevatorLeadCurve}
           trailCurve={elevatorTrailCurve}
+          frontRadius={elevatorFrontRadius}
+          backRadius={elevatorBackRadius}
           wireframe={wireframe}
           position={[0, fuselageParams.tailHeight, fuselageParams.length / 2]}
         />

--- a/src/components/Elevator.jsx
+++ b/src/components/Elevator.jsx
@@ -10,46 +10,78 @@ function createElevatorGeometry({
   trailCurve = 1,
   mirrored = true,
   vAngle = 0,
+  frontRadius = 0,
+  backRadius = 0,
 }) {
-  const segments = 20;
+  const edgeSegments = 20;
+  const shape = new THREE.Shape();
+
+  const lead = (t) => sweep * Math.pow(t, leadCurve);
+  const trail = (t) =>
+    rootChord + (sweep + tipChord - rootChord) * Math.pow(t, trailCurve);
+
+  const backEnd = 1 - backRadius / span;
+  const frontEnd = 1 - frontRadius / span;
+
+  shape.moveTo(0, trail(0));
+  for (let i = 1; i <= edgeSegments; i++) {
+    const t = backEnd * (i / edgeSegments);
+    shape.lineTo(span * t, trail(t));
+  }
+
+  const backZ = trail(backEnd);
+  if (backRadius > 0) {
+    shape.lineTo(span - backRadius, backZ);
+    shape.quadraticCurveTo(span, backZ, span, backZ - backRadius);
+  } else {
+    shape.lineTo(span, trail(1));
+  }
+
+  const sideEnd = frontRadius > 0 ? lead(frontEnd) + frontRadius : lead(1);
+  shape.lineTo(span, sideEnd);
+
+  const frontZ = lead(frontEnd);
+  if (frontRadius > 0) {
+    shape.quadraticCurveTo(span, frontZ, span - frontRadius, frontZ);
+  } else {
+    shape.lineTo(span, frontZ);
+  }
+
+  for (let i = edgeSegments; i >= 0; i--) {
+    const t = frontEnd * (i / edgeSegments);
+    shape.lineTo(span * t, lead(t));
+  }
+
+  shape.closePath();
+
+  const geom2d = new THREE.ShapeGeometry(shape);
+
+  const pos = geom2d.attributes.position.array;
+  const vertCount = pos.length / 3;
   const vertices = [];
-  const indices = [];
-
-  const lead = [];
-  const trail = [];
-  for (let i = 0; i <= segments; i++) {
-    const t = i / segments;
-    const x = span * t;
-    const leadZ = sweep * Math.pow(t, leadCurve);
-    const trailZ = rootChord + (sweep + tipChord - rootChord) * Math.pow(t, trailCurve);
+  for (let i = 0; i < vertCount; i++) {
+    const x = pos[i * 3];
+    const z = pos[i * 3 + 1];
     const y = Math.tan((vAngle * Math.PI) / 180) * x;
-    lead.push([x, y, leadZ]);
-    trail.push([x, y, trailZ]);
+    vertices.push(x, y, z);
   }
 
-  // Create vertices for one side
-  lead.forEach((p) => vertices.push(...p));
-  trail.forEach((p) => vertices.push(...p));
+  const indices = Array.from(geom2d.index.array);
 
-  for (let i = 0; i < segments; i++) {
-    const lf = i;
-    const rf = i + 1;
-    const lb = i + lead.length;
-    const rb = i + 1 + lead.length;
-    indices.push(lf, rf, lb);
-    indices.push(rf, rb, lb);
-  }
-
-  // Mirror
+  let mirroredVertices = [];
+  let mirroredIndices = [];
   if (mirrored) {
-    const offset = vertices.length / 3;
-    vertices.push(...vertices.map((v, idx) => (idx % 3 === 0 ? -v : v)));
-    indices.push(...indices.map((idx) => idx + offset));
+    const offset = vertCount;
+    mirroredVertices = vertices.map((v, idx) => (idx % 3 === 0 ? -v : v));
+    mirroredIndices = indices.map((idx) => idx + offset);
   }
 
   const geom = new THREE.BufferGeometry();
-  geom.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3));
-  geom.setIndex(indices);
+  geom.setAttribute(
+    'position',
+    new THREE.Float32BufferAttribute([...vertices, ...mirroredVertices], 3),
+  );
+  geom.setIndex([...indices, ...mirroredIndices]);
   geom.computeVertexNormals();
   return geom;
 }
@@ -63,6 +95,8 @@ export default function Elevator({
   sweep = 0,
   leadCurve = 1,
   trailCurve = 1,
+  frontRadius = 0,
+  backRadius = 0,
   wireframe = false,
   position = [0, 0, 0],
 }) {
@@ -75,14 +109,27 @@ export default function Elevator({
         sweep,
         leadCurve,
         trailCurve,
+        frontRadius,
+        backRadius,
         mirrored: true,
         vAngle: type === 'V' ? vAngle : 0,
       }),
-    [rootChord, tipChord, span, sweep, leadCurve, trailCurve, vAngle, type],
+    [
+      rootChord,
+      tipChord,
+      span,
+      sweep,
+      leadCurve,
+      trailCurve,
+      frontRadius,
+      backRadius,
+      vAngle,
+      type,
+    ],
   );
 
   return (
-    <mesh geometry={geom} position={position} rotation={[0, Math.PI / 2, 0]}>
+    <mesh geometry={geom} position={position} rotation={[0, -Math.PI / 2, 0]}>
       <meshStandardMaterial color="white" side={THREE.DoubleSide} wireframe={wireframe} />
     </mesh>
   );


### PR DESCRIPTION
## Summary
- rotate the elevator mesh clockwise
- add optional front/back radius controls to the elevator
- expose new corner radius settings in the UI

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688278e7960c8330a24ee38fdaf93883