### PR TITLE
Remove wing curvature controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,3 @@ If you are developing a production application, we recommend using TypeScript wi
 - The top front and back corners of the rudder have independent radius controls.
 - Curve settings now control how those corners are rounded.
 - The fuselage can be hidden entirely if desired.
-- Leading and trailing edges of the wing can be curved using new controls.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -43,8 +43,6 @@ export default function App({ showAirfoilControls = false } = {}) {
   const groupRef = useRef();
   const {
     sweep,
-    leadCurve,
-    trailCurve,
     mirrored,
     enablePanel1,
     enablePanel2,
@@ -52,8 +50,6 @@ export default function App({ showAirfoilControls = false } = {}) {
     mountZ,
   } = useControls('Wing Settings', {
     sweep: num(0, { min: -300, max: 300 }),
-    leadCurve: num(1, { min: 0.1, max: 5, step: 0.1, label: 'Leading Edge Curve' }),
-    trailCurve: num(1, { min: 0.1, max: 5, step: 0.1, label: 'Trailing Edge Curve' }),
     mirrored: true,
     mountHeight: num(0, { min: -30, max: 30, step: 1, label: 'Mount Height' }),
     mountZ: num(0, { min: -300, max: 300, step: 1, label: 'Mount Position' }),
@@ -328,8 +324,6 @@ export default function App({ showAirfoilControls = false } = {}) {
                 elevatorTrailCurve={elevatorTrailCurve}
                 elevatorFrontRadius={elevatorFrontRadius}
                 elevatorBackRadius={elevatorBackRadius}
-                leadCurve={leadCurve}
-                trailCurve={trailCurve}
                 showFuselage={fuselageParams.showFuselage}
                 fuselageParams={fuselageParams}
               />
@@ -377,11 +371,9 @@ export default function App({ showAirfoilControls = false } = {}) {
                 elevatorTrailCurve={elevatorTrailCurve}
                 elevatorFrontRadius={elevatorFrontRadius}
                 elevatorBackRadius={elevatorBackRadius}
-                leadCurve={leadCurve}
-                trailCurve={trailCurve}
-                 showFuselage={fuselageParams.showFuselage}
-                 fuselageParams={fuselageParams}
-                 wireframe
+                showFuselage={fuselageParams.showFuselage}
+                fuselageParams={fuselageParams}
+                wireframe
                />
               </MiniView>
               <MiniView position={[0, 400, 0]} up={[0, 0, 1]}>
@@ -415,11 +407,9 @@ export default function App({ showAirfoilControls = false } = {}) {
                 elevatorTrailCurve={elevatorTrailCurve}
                 elevatorFrontRadius={elevatorFrontRadius}
                 elevatorBackRadius={elevatorBackRadius}
-                leadCurve={leadCurve}
-                trailCurve={trailCurve}
-                 showFuselage={fuselageParams.showFuselage}
-                 fuselageParams={fuselageParams}
-                 wireframe
+                showFuselage={fuselageParams.showFuselage}
+                fuselageParams={fuselageParams}
+                wireframe
                />
               </MiniView>
             </div>

--- a/src/components/Aircraft.jsx
+++ b/src/components/Aircraft.jsx
@@ -7,8 +7,6 @@ import Elevator from './Elevator';
 export default function Aircraft({
   sections,
   sweep,
-  leadCurve = 1,
-  trailCurve = 1,
   mirrored,
   mountHeight,
   mountZ,
@@ -110,8 +108,6 @@ export default function Aircraft({
         sections={sections}
         sweep={sweep}
         mirrored={mirrored}
-        leadCurve={leadCurve}
-        trailCurve={trailCurve}
         mountHeight={mountHeight}
         mountZ={mountZ}
         showNacelles={showNacelles}

--- a/src/components/Wing.jsx
+++ b/src/components/Wing.jsx
@@ -61,7 +61,9 @@ function rotateAirfoil(points, angle, chord, pivotRatio = 1) {
   });
 }
 
-function createWingGeometry(sections, sweep, mirrored, leadCurve = 1, trailCurve = 1) {
+function createWingGeometry(sections, sweep, mirrored) {
+  const leadCurve = 1;
+  const trailCurve = 1;
   const vertices = [];
   const indices = [];
   let yOffset = 0;
@@ -151,7 +153,9 @@ function createWingGeometry(sections, sweep, mirrored, leadCurve = 1, trailCurve
   return wingGeom;
 }
 
-function computeNacellePositions(sections, sweep, leadCurve = 1, trailCurve = 1) {
+function computeNacellePositions(sections, sweep) {
+  const leadCurve = 1;
+  const trailCurve = 1;
   const xPositions = [0];
   for (let i = 0; i < sections.length - 1; i++) {
     const len = sections[i].length || 0;
@@ -186,8 +190,6 @@ export default function Wing({
   sections,
   sweep,
   mirrored,
-  leadCurve = 1,
-  trailCurve = 1,
   mountHeight = 0,
   mountZ = 0,
   wireframe = false,
@@ -196,11 +198,11 @@ export default function Wing({
   nacelleLength = 40,
 }) {
   const geom = useMemo(() => {
-    return createWingGeometry(sections, sweep, mirrored, leadCurve, trailCurve);
-  }, [sections, sweep, mirrored, leadCurve, trailCurve]);
+    return createWingGeometry(sections, sweep, mirrored);
+  }, [sections, sweep, mirrored]);
   const nacellePositions = useMemo(
-    () => computeNacellePositions(sections, sweep, leadCurve, trailCurve),
-    [sections, sweep, leadCurve, trailCurve],
+    () => computeNacellePositions(sections, sweep),
+    [sections, sweep],
   );
 
   return (


### PR DESCRIPTION
## Summary
- drop wing curvature options from UI and aircraft model
- lock wing geometry to straight leading and trailing edges
- remove outdated README bullet

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6883ac9040c8833097ba3f4b7abb21f7