### PR TITLE
Add configurable elevator controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,5 @@ If you are developing a production application, we recommend using TypeScript wi
 - The top front and back corners of the rudder have independent radius controls.
 - Curve settings now control how those corners are rounded.
 - The fuselage can be hidden entirely if desired.
+- Elevator geometry can now be customized with independent root and tip chords,
+  span, sweep, dihedral and airfoil settings.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -99,7 +99,6 @@ export default function App({ showAirfoilControls = false } = {}) {
     pivotPercent: num(100, { min: 0, max: 100, step: 1, label: 'Rotation Center (%)' }),
   });
 
-  const elevatorScale = 0.5;
 
   const fuselageParams = useControls('Fuselage', {
     showFuselage: { value: true, label: 'Show Fuselage' },
@@ -172,7 +171,29 @@ export default function App({ showAirfoilControls = false } = {}) {
     backCurve: num(1, { min: 0.1, max: 5, step: 0.1, label: 'Back Curve' }),
   });
 
-  const { showElevator } = useControls('Elevator', { showElevator: false });
+  const {
+    showElevator,
+    elevatorRootChord,
+    elevatorTipChord,
+    elevatorSpan,
+    elevatorSweep,
+    elevatorDihedral,
+    elevatorThickness,
+    elevatorCamber,
+    elevatorCamberPos,
+    elevatorAngle,
+  } = useControls('Elevator', {
+    showElevator: false,
+    elevatorRootChord: num(50, { min: 10, max: 200, step: 1, label: 'Root Chord' }),
+    elevatorTipChord: num(50, { min: 10, max: 200, step: 1, label: 'Tip Chord' }),
+    elevatorSpan: num(80, { min: 10, max: 300, step: 1, label: 'Span' }),
+    elevatorSweep: num(0, { min: -45, max: 45, step: 1, label: 'Sweep (°)' }),
+    elevatorDihedral: num(0, { min: -20, max: 20, step: 0.1, label: 'Dihedral (°)' }),
+    elevatorThickness: num(0.12, { min: 0.05, max: 0.25, label: 'Thickness' }),
+    elevatorCamber: num(0.02, { min: 0, max: 0.1, label: 'Camber' }),
+    elevatorCamberPos: num(0.4, { min: 0.1, max: 0.9, label: 'Camber Pos' }),
+    elevatorAngle: num(0, { min: -15, max: 15, step: 0.1, label: 'Angle of Attack (°)' }),
+  });
 
   const sections = [rootParams];
   if (enablePanel1) sections.push(panel1Params);
@@ -292,8 +313,15 @@ export default function App({ showAirfoilControls = false } = {}) {
                 backRadius={backRadius}
                 rudderOffset={rudderOffset}
                 showElevator={showElevator}
-                rootSection={rootParams}
-                elevatorScale={elevatorScale}
+                elevatorRootChord={elevatorRootChord}
+                elevatorTipChord={elevatorTipChord}
+                elevatorSpan={elevatorSpan}
+                elevatorSweep={elevatorSweep}
+                elevatorDihedral={elevatorDihedral}
+                elevatorThickness={elevatorThickness}
+                elevatorCamber={elevatorCamber}
+                elevatorCamberPos={elevatorCamberPos}
+                elevatorAngle={elevatorAngle}
                 showFuselage={fuselageParams.showFuselage}
                 fuselageParams={fuselageParams}
               />
@@ -331,8 +359,15 @@ export default function App({ showAirfoilControls = false } = {}) {
                  backRadius={backRadius}
                 rudderOffset={rudderOffset}
                 showElevator={showElevator}
-                rootSection={rootParams}
-                elevatorScale={elevatorScale}
+                elevatorRootChord={elevatorRootChord}
+                elevatorTipChord={elevatorTipChord}
+                elevatorSpan={elevatorSpan}
+                elevatorSweep={elevatorSweep}
+                elevatorDihedral={elevatorDihedral}
+                elevatorThickness={elevatorThickness}
+                elevatorCamber={elevatorCamber}
+                elevatorCamberPos={elevatorCamberPos}
+                elevatorAngle={elevatorAngle}
                 showFuselage={fuselageParams.showFuselage}
                 fuselageParams={fuselageParams}
                 wireframe
@@ -359,8 +394,15 @@ export default function App({ showAirfoilControls = false } = {}) {
                  backRadius={backRadius}
                 rudderOffset={rudderOffset}
                 showElevator={showElevator}
-                rootSection={rootParams}
-                elevatorScale={elevatorScale}
+                elevatorRootChord={elevatorRootChord}
+                elevatorTipChord={elevatorTipChord}
+                elevatorSpan={elevatorSpan}
+                elevatorSweep={elevatorSweep}
+                elevatorDihedral={elevatorDihedral}
+                elevatorThickness={elevatorThickness}
+                elevatorCamber={elevatorCamber}
+                elevatorCamberPos={elevatorCamberPos}
+                elevatorAngle={elevatorAngle}
                 showFuselage={fuselageParams.showFuselage}
                 fuselageParams={fuselageParams}
                 wireframe

--- a/src/components/Aircraft.jsx
+++ b/src/components/Aircraft.jsx
@@ -28,8 +28,15 @@ export default function Aircraft({
   backRadius = 0,
   rudderOffset = 0,
   showElevator = false,
-  rootSection,
-  elevatorScale = 0.5,
+  elevatorRootChord = 50,
+  elevatorTipChord = 50,
+  elevatorSpan = 80,
+  elevatorSweep = 0,
+  elevatorDihedral = 0,
+  elevatorThickness = 0.12,
+  elevatorCamber = 0.02,
+  elevatorCamberPos = 0.4,
+  elevatorAngle = 0,
 }) {
   return (
     <group ref={groupRef}>
@@ -82,8 +89,15 @@ export default function Aircraft({
       )}
       {showElevator && (
         <Elevator
-          rootSection={rootSection}
-          scale={elevatorScale}
+          rootChord={elevatorRootChord}
+          tipChord={elevatorTipChord}
+          span={elevatorSpan}
+          sweep={elevatorSweep}
+          dihedral={elevatorDihedral}
+          thickness={elevatorThickness}
+          camber={elevatorCamber}
+          camberPos={elevatorCamberPos}
+          angle={elevatorAngle}
           wireframe={wireframe}
           position={[0, fuselageParams.tailHeight, fuselageParams.length / 2]}
         />

--- a/src/components/Elevator.jsx
+++ b/src/components/Elevator.jsx
@@ -2,25 +2,44 @@ import React from 'react';
 import Wing from './Wing';
 
 export default function Elevator({
-  rootSection,
-  scale = 0.5,
+  rootChord = 50,
+  tipChord = 50,
+  span = 80,
+  sweep = 0,
+  dihedral = 0,
+  thickness = 0.12,
+  camber = 0.02,
+  camberPos = 0.4,
+  angle = 0,
   position = [0, 0, 0],
   wireframe = false,
 }) {
-  if (!rootSection) return null;
-
-  const section = {
-    ...rootSection,
-    chord: rootSection.chord * scale,
-    length: (rootSection.length || 0) * scale,
+  const root = {
+    chord: rootChord,
+    thickness,
+    camber,
+    camberPos,
+    angle,
+    length: span,
+    dihedral,
   };
 
-  const sections = [section, { ...section }];
+  const tip = {
+    chord: tipChord,
+    thickness,
+    camber,
+    camberPos,
+    angle,
+    length: 0,
+    dihedral,
+  };
+
+  const sections = [root, tip];
 
   return (
     <Wing
       sections={sections}
-      sweep={0}
+      sweep={sweep}
       mirrored
       mountHeight={position[1]}
       mountZ={position[2]}


### PR DESCRIPTION
## Summary
- let elevator geometry be fully configurable
- wire elevator settings through `Aircraft` and `App`
- document new feature in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6883b70691ec8330a4b12d96bf72f4c0