### PR TITLE
Adjust Airfoil step previews and controls

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -135,7 +135,7 @@ export default function App({ showAirfoilControls = false } = {}) {
     tailcapSharpness: num(1, { min: 0.1, max: 5, step: 0.1, label: 'Tail Cap Sharpness' }),
     showCrossSections: { value: false, label: 'Show Cross Sections' },
     segmentCount: num(10, { min: 2, max: 50, step: 1, label: 'Segment Count' }),
-  });
+  }, { render: () => !showAirfoilControls });
 
   const {
     showNacelles,
@@ -145,7 +145,7 @@ export default function App({ showAirfoilControls = false } = {}) {
     showNacelles: false,
     nacelleRadius: num(10, { min: 1, max: 100, step: 1, label: 'Radius' }),
     nacelleLength: num(40, { min: 10, max: 200, step: 1, label: 'Length' }),
-  });
+  }, { render: () => !showAirfoilControls });
 
   const {
     showRudder,

--- a/src/components/AirfoilPreview.jsx
+++ b/src/components/AirfoilPreview.jsx
@@ -78,7 +78,7 @@ export default function AirfoilPreview({ chord, thickness, camber, camberPos, an
   return (
     <div style={{ marginTop: '16px', width: '100%' }}>
       <div style={{ color: 'white', marginBottom: '4px' }}>{label} (inches)</div>
-      <svg viewBox={viewBox} width="100%" height="100" preserveAspectRatio="xMidYMid meet">
+      <svg viewBox={viewBox} width="100%" height="200" preserveAspectRatio="xMidYMid meet">
         {/* Grid lines */}
         {gridLines.map((x, i) => (
           <line


### PR DESCRIPTION
## Summary
- hide Fuselage and Nacelles folders when viewing the Airfoils step
- enlarge airfoil preview SVGs to 200px high

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688cc4f64cf88330b99d75a583ca0275