### PR TITLE
Refactor fuselage generator for front/back sections and alignment

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -102,37 +102,20 @@ export default function App({ showAirfoilControls = false } = {}) {
 
   const fuselageParams = useControls('Fuselage', {
     showFuselage: { value: true, label: 'Show Fuselage' },
-    topShape: { value: 'Square', options: ['Square', 'Ellipse'], label: 'Top Shape' },
-    bottomShape: { value: 'Square', options: ['Square', 'Ellipse'], label: 'Bottom Shape' },
     length: num(200, { min: 50, max: 600 }),
-    width: num(40, { min: 10, max: 200 }),
-    height: num(40, { min: 10, max: 200 }),
-    taperH: num(0.8, { min: 0.1, max: 1, step: 0.01, label: 'Horizontal Taper' }),
-    taperTop: num(0.8, { min: 0.1, max: 1, step: 0.01, label: 'Top Taper' }),
-    taperBottom: num(0.8, { min: 0.1, max: 1, step: 0.01, label: 'Bottom Taper' }),
-    taperPosH: num(0, { min: 0, max: 1, step: 0.01, label: 'Horizontal Taper Start' }),
-    taperPosV: num(0, { min: 0, max: 1, step: 0.01, label: 'Vertical Taper Start' }),
-    topCornerRadius: {
-      ...num(10, { min: 0, max: 50, label: 'Top Corner Radius' }),
-      render: (get) =>
-        get('Fuselage.topShape') === 'Square' ||
-        get('Fuselage.bottomShape') === 'Square',
-    },
-    bottomCornerRadius: {
-      ...num(10, { min: 0, max: 50, label: 'Bottom Corner Radius' }),
-      render: (get) =>
-        get('Fuselage.topShape') === 'Square' ||
-        get('Fuselage.bottomShape') === 'Square',
-    },
-    curveH: num(1, { min: 0.1, max: 5, step: 0.1, label: 'Horizontal Taper Curve' }),
-    curveV: num(1, { min: 0.1, max: 5, step: 0.1, label: 'Vertical Taper Curve' }),
+    frontWidth: num(40, { min: 10, max: 200, label: 'Front Width' }),
+    frontHeight: num(40, { min: 10, max: 200, label: 'Front Height' }),
+    backWidth: num(40, { min: 10, max: 200, label: 'Back Width' }),
+    backHeight: num(40, { min: 10, max: 200, label: 'Back Height' }),
+    cornerRadius: num(10, { min: 0, max: 50, label: 'Corner Radius' }),
+    curveH: num(1, { min: 0.1, max: 5, step: 0.1, label: 'Width Curve' }),
+    curveV: num(1, { min: 0.1, max: 5, step: 0.1, label: 'Height Curve' }),
+    verticalAlign: num(0.5, { min: 0, max: 1, step: 0.01, label: 'Vertical Align' }),
     tailHeight: num(0, { min: -100, max: 100, step: 1, label: 'Tail Height' }),
     closeNose: { value: false, label: 'Close Nose' },
     closeTail: { value: false, label: 'Close Tail' },
     nosecapLength: num(20, { min: 1, max: 100, step: 1, label: 'Nose Cap Length' }),
-    nosecapSharpness: num(1, { min: 0.1, max: 5, step: 0.1, label: 'Nose Cap Sharpness' }),
     tailcapLength: num(20, { min: 1, max: 100, step: 1, label: 'Tail Cap Length' }),
-    tailcapSharpness: num(1, { min: 0.1, max: 5, step: 0.1, label: 'Tail Cap Sharpness' }),
     showCrossSections: { value: false, label: 'Show Cross Sections' },
     segmentCount: num(10, { min: 2, max: 50, step: 1, label: 'Segment Count' }),
   }, { render: () => !showAirfoilControls });

--- a/src/components/Aircraft.jsx
+++ b/src/components/Aircraft.jsx
@@ -36,24 +36,24 @@ export default function Aircraft({
   elevatorAngle = 0,
   elevatorOffset = 0,
 }) {
+  const tailCenterY =
+    (0.5 - fuselageParams.verticalAlign) *
+      (fuselageParams.frontHeight - fuselageParams.backHeight) +
+    fuselageParams.tailHeight;
+
   return (
     <group ref={groupRef}>
       {showFuselage && (
         <Fuselage
           length={fuselageParams.length}
-          width={fuselageParams.width}
-          height={fuselageParams.height}
-          topShape={fuselageParams.topShape}
-          bottomShape={fuselageParams.bottomShape}
-          taperH={fuselageParams.taperH}
-          taperTop={fuselageParams.taperTop}
-          taperBottom={fuselageParams.taperBottom}
-          taperPosH={fuselageParams.taperPosH}
-          taperPosV={fuselageParams.taperPosV}
-          topCornerRadius={fuselageParams.topCornerRadius}
-          bottomCornerRadius={fuselageParams.bottomCornerRadius}
+          frontWidth={fuselageParams.frontWidth}
+          frontHeight={fuselageParams.frontHeight}
+          backWidth={fuselageParams.backWidth}
+          backHeight={fuselageParams.backHeight}
+          cornerRadius={fuselageParams.cornerRadius}
           curveH={fuselageParams.curveH}
           curveV={fuselageParams.curveV}
+          verticalAlign={fuselageParams.verticalAlign}
           tailHeight={fuselageParams.tailHeight}
           segmentCount={fuselageParams.segmentCount}
           debugCrossSections={fuselageParams.showCrossSections}
@@ -61,9 +61,7 @@ export default function Aircraft({
           closeNose={fuselageParams.closeNose}
           closeTail={fuselageParams.closeTail}
           nosecapLength={fuselageParams.nosecapLength}
-          nosecapSharpness={fuselageParams.nosecapSharpness}
           tailcapLength={fuselageParams.tailcapLength}
-          tailcapSharpness={fuselageParams.tailcapSharpness}
         />
       )}
       {showRudder && (
@@ -77,7 +75,7 @@ export default function Aircraft({
           wireframe={wireframe}
           position={[
             0,
-            fuselageParams.tailHeight + fuselageParams.height / 2,
+            tailCenterY + fuselageParams.backHeight / 2,
             fuselageParams.length / 2,
           ]}
         />
@@ -95,7 +93,7 @@ export default function Aircraft({
           angle={elevatorAngle}
           wireframe={wireframe}
           offset={elevatorOffset}
-          position={[0, fuselageParams.tailHeight, fuselageParams.length / 2]}
+          position={[0, tailCenterY, fuselageParams.length / 2]}
         />
       )}
       <Wing


### PR DESCRIPTION
## Summary
- Generate fuselage from explicit front/back rounded rectangles with power-curve scaling
- Support vertical alignment of cross-sections and tail surfaces
- Update controls and aircraft assembly to use new fuselage parameters

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68951dc12ab48330b48a9fe4216549cc