### PR TITLE
Add per-panel configurable nacelles with fins

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ If you are developing a production application, we recommend using TypeScript wi
 - Adjustable fuselage height independent of width.
 - Option to choose an elliptical or square fuselage shape.
 - Optional nacelles can be added at the end of each wing panel.
+- Nacelles can be toggled per wing panel and support fuselage-style geometry options with optional top or bottom fins.
 - A rudder can be added to the rear of the fuselage.
 - The rudder now uses the same sweep and chord controls as a wing
   (without mirroring or airfoil support).

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -77,6 +77,13 @@ export default function App({ showAirfoilControls = false } = {}) {
     angle: num(0, { min: -15, max: 15, step: 0.1, label: 'Angle of Attack (°)' }),
     pivotPercent: num(100, { min: 0, max: 100, step: 1, label: 'Rotation Center (%)' }),
     dihedral: num(0, { min: -20, max: 20, step: 0.1, label: 'Dihedral (°)' }),
+    nacelle: { value: false, label: 'Nacelle' },
+    nacelleFin: {
+      value: 'none',
+      options: { None: 'none', Top: 'top', Bottom: 'bottom' },
+      label: 'Nacelle Fin',
+      render: (get) => get('Panel 1 Airfoil.nacelle'),
+    },
   }, { render: (get) => get('Wing Settings.enablePanel1') });
 
   const panel2Params = useControls('Panel 2 Airfoil', {
@@ -88,6 +95,13 @@ export default function App({ showAirfoilControls = false } = {}) {
     angle: num(0, { min: -15, max: 15, step: 0.1, label: 'Angle of Attack (°)' }),
     pivotPercent: num(100, { min: 0, max: 100, step: 1, label: 'Rotation Center (%)' }),
     dihedral: num(0, { min: -20, max: 20, step: 0.1, label: 'Dihedral (°)' }),
+    nacelle: { value: false, label: 'Nacelle' },
+    nacelleFin: {
+      value: 'none',
+      options: { None: 'none', Top: 'top', Bottom: 'bottom' },
+      label: 'Nacelle Fin',
+      render: (get) => get('Panel 2 Airfoil.nacelle'),
+    },
   }, { render: (get) => get('Wing Settings.enablePanel2') });
 
   const tipParams = useControls('Wing Tip', {
@@ -97,6 +111,13 @@ export default function App({ showAirfoilControls = false } = {}) {
     camberPos: num(0.4, { min: 0.1, max: 0.9, render: () => showAirfoilControls }),
     angle: num(0, { min: -15, max: 15, step: 0.1, label: 'Angle of Attack (°)' }),
     pivotPercent: num(100, { min: 0, max: 100, step: 1, label: 'Rotation Center (%)' }),
+    nacelle: { value: false, label: 'Nacelle' },
+    nacelleFin: {
+      value: 'none',
+      options: { None: 'none', Top: 'top', Bottom: 'bottom' },
+      label: 'Nacelle Fin',
+      render: (get) => get('Wing Tip.nacelle'),
+    },
   });
 
 
@@ -122,12 +143,50 @@ export default function App({ showAirfoilControls = false } = {}) {
 
   const {
     showNacelles,
-    nacelleRadius,
-    nacelleLength,
+    length: nacelleLength,
+    frontWidth: nacelleFrontWidth,
+    frontHeight: nacelleFrontHeight,
+    backWidth: nacelleBackWidth,
+    backHeight: nacelleBackHeight,
+    cornerRadius: nacelleCornerRadius,
+    curveH: nacelleCurveH,
+    curveV: nacelleCurveV,
+    verticalAlign: nacelleVerticalAlign,
+    tailHeight: nacelleTailHeight,
+    closeNose: nacelleCloseNose,
+    closeTail: nacelleCloseTail,
+    nosecapLength: nacelleNosecapLength,
+    tailcapLength: nacelleTailcapLength,
+    segmentCount: nacelleSegmentCount,
+    finHeight,
+    finRootChord,
+    finTipChord,
+    finSweep,
+    finThickness,
+    finOffset,
   } = useControls('Nacelles', {
     showNacelles: false,
-    nacelleRadius: num(10, { min: 1, max: 100, step: 1, label: 'Radius' }),
-    nacelleLength: num(40, { min: 10, max: 200, step: 1, label: 'Length' }),
+    length: num(40, { min: 10, max: 200, step: 1, label: 'Length' }),
+    frontWidth: num(20, { min: 1, max: 100, step: 1, label: 'Front Width' }),
+    frontHeight: num(20, { min: 1, max: 100, step: 1, label: 'Front Height' }),
+    backWidth: num(20, { min: 1, max: 100, step: 1, label: 'Back Width' }),
+    backHeight: num(20, { min: 1, max: 100, step: 1, label: 'Back Height' }),
+    cornerRadius: num(5, { min: 0, max: 50, step: 1, label: 'Corner Radius' }),
+    curveH: num(1, { min: 0.1, max: 5, step: 0.1, label: 'Width Curve' }),
+    curveV: num(1, { min: 0.1, max: 5, step: 0.1, label: 'Height Curve' }),
+    verticalAlign: num(0.5, { min: 0, max: 1, step: 0.01, label: 'Vertical Align' }),
+    tailHeight: num(0, { min: -50, max: 50, step: 1, label: 'Tail Height' }),
+    closeNose: { value: false, label: 'Close Nose' },
+    closeTail: { value: false, label: 'Close Tail' },
+    nosecapLength: num(5, { min: 0, max: 50, step: 1, label: 'Nose Cap Length' }),
+    tailcapLength: num(5, { min: 0, max: 50, step: 1, label: 'Tail Cap Length' }),
+    segmentCount: num(10, { min: 2, max: 50, step: 1, label: 'Segment Count' }),
+    finHeight: num(10, { min: 1, max: 100, step: 1, label: 'Fin Height' }),
+    finRootChord: num(15, { min: 1, max: 100, step: 1, label: 'Fin Root Chord' }),
+    finTipChord: num(0, { min: 0, max: 100, step: 1, label: 'Fin Tip Chord' }),
+    finSweep: num(0, { min: -300, max: 300, step: 1, label: 'Fin Sweep' }),
+    finThickness: num(1, { min: 0.1, max: 10, step: 0.1, label: 'Fin Thickness' }),
+    finOffset: num(0, { min: -100, max: 100, step: 1, label: 'Fin Offset' }),
   }, { render: () => !showAirfoilControls });
 
   const {
@@ -175,9 +234,45 @@ export default function App({ showAirfoilControls = false } = {}) {
   });
 
   const sections = [rootParams];
-  if (enablePanel1) sections.push(panel1Params);
-  if (enablePanel2) sections.push(panel2Params);
+  const nacelleFlags = [];
+  const nacelleFins = [];
+  if (enablePanel1) {
+    sections.push(panel1Params);
+    nacelleFlags.push(panel1Params.nacelle);
+    nacelleFins.push(panel1Params.nacelleFin === 'none' ? null : panel1Params.nacelleFin);
+    if (enablePanel2) {
+      sections.push(panel2Params);
+      nacelleFlags.push(panel2Params.nacelle);
+      nacelleFins.push(panel2Params.nacelleFin === 'none' ? null : panel2Params.nacelleFin);
+    }
+  }
   sections.push(tipParams);
+  nacelleFlags.push(tipParams.nacelle);
+  nacelleFins.push(tipParams.nacelleFin === 'none' ? null : tipParams.nacelleFin);
+
+  const nacelleParams = {
+    length: nacelleLength,
+    frontWidth: nacelleFrontWidth,
+    frontHeight: nacelleFrontHeight,
+    backWidth: nacelleBackWidth,
+    backHeight: nacelleBackHeight,
+    cornerRadius: nacelleCornerRadius,
+    curveH: nacelleCurveH,
+    curveV: nacelleCurveV,
+    verticalAlign: nacelleVerticalAlign,
+    tailHeight: nacelleTailHeight,
+    closeNose: nacelleCloseNose,
+    closeTail: nacelleCloseTail,
+    nosecapLength: nacelleNosecapLength,
+    tailcapLength: nacelleTailcapLength,
+    segmentCount: nacelleSegmentCount,
+    finHeight,
+    finRootChord,
+    finTipChord,
+    finSweep,
+    finThickness,
+    finOffset,
+  };
 
   const previewElements = (
     <>
@@ -279,8 +374,9 @@ export default function App({ showAirfoilControls = false } = {}) {
                 mountHeight={mountHeight}
                 mountZ={mountZ}
                 showNacelles={showNacelles}
-                nacelleRadius={nacelleRadius}
-                nacelleLength={nacelleLength}
+                nacelleParams={nacelleParams}
+                nacelleFlags={nacelleFlags}
+                nacelleFins={nacelleFins}
                 showRudder={showRudder}
                 rudderHeight={rudderHeight}
                 rootChord={rootChord}
@@ -323,8 +419,9 @@ export default function App({ showAirfoilControls = false } = {}) {
                   mountHeight={mountHeight}
                   mountZ={mountZ}
                   showNacelles={showNacelles}
-                  nacelleRadius={nacelleRadius}
-                  nacelleLength={nacelleLength}
+                  nacelleParams={nacelleParams}
+                  nacelleFlags={nacelleFlags}
+                  nacelleFins={nacelleFins}
                   showRudder={showRudder}
                   rudderHeight={rudderHeight}
                   rootChord={rootChord}
@@ -356,8 +453,9 @@ export default function App({ showAirfoilControls = false } = {}) {
                   mountHeight={mountHeight}
                   mountZ={mountZ}
                   showNacelles={showNacelles}
-                  nacelleRadius={nacelleRadius}
-                  nacelleLength={nacelleLength}
+                  nacelleParams={nacelleParams}
+                  nacelleFlags={nacelleFlags}
+                  nacelleFins={nacelleFins}
                   showRudder={showRudder}
                   rudderHeight={rudderHeight}
                   rootChord={rootChord}

--- a/src/components/Aircraft.jsx
+++ b/src/components/Aircraft.jsx
@@ -15,8 +15,9 @@ export default function Aircraft({
   wireframe = false,
   showFuselage = true,
   showNacelles = false,
-  nacelleRadius = 10,
-  nacelleLength = 40,
+  nacelleParams = {},
+  nacelleFlags = [],
+  nacelleFins = [],
   showRudder = false,
   rudderHeight = 40,
   rootChord = 30,
@@ -103,8 +104,9 @@ export default function Aircraft({
         mountHeight={mountHeight}
         mountZ={mountZ}
         showNacelles={showNacelles}
-        nacelleRadius={nacelleRadius}
-        nacelleLength={nacelleLength}
+        nacelleParams={nacelleParams}
+        nacelleFlags={nacelleFlags}
+        nacelleFins={nacelleFins}
         wireframe={wireframe}
       />
     </group>

--- a/src/components/Fuselage.jsx
+++ b/src/components/Fuselage.jsx
@@ -170,6 +170,7 @@ export default function Fuselage(props) {
     segmentCount = 20,
     debugCrossSections = false,
     wireframe = false,
+    color = 'gray',
   } = props;
 
   const { geometry, crossSections } = useMemo(
@@ -213,7 +214,7 @@ export default function Fuselage(props) {
   return (
     <group>
       <mesh geometry={geometry}>
-        <meshStandardMaterial color="gray" side={THREE.DoubleSide} wireframe={wireframe} />
+        <meshStandardMaterial color={color} side={THREE.DoubleSide} wireframe={wireframe} />
       </mesh>
       {debugCrossSections && crossSections.map((sec, idx) => {
         const g = new THREE.BufferGeometry().setFromPoints(

--- a/src/components/Nacelle.jsx
+++ b/src/components/Nacelle.jsx
@@ -1,11 +1,76 @@
-import React, { useMemo } from 'react';
-import * as THREE from 'three';
+import React from 'react';
+import Fuselage from './Fuselage';
+import Rudder from './Rudder';
 
-export default function Nacelle({ length = 40, radius = 10, position = [0, 0, 0], wireframe = false }) {
-  const geom = useMemo(() => new THREE.CylinderGeometry(radius, radius, length, 16), [radius, length]);
+export default function Nacelle({
+  position = [0, 0, 0],
+  wireframe = false,
+  fin = null, // 'top' | 'bottom' | null
+  length = 40,
+  frontWidth = 20,
+  frontHeight = 20,
+  backWidth = 20,
+  backHeight = 20,
+  cornerRadius = 0,
+  curveH = 1,
+  curveV = 1,
+  verticalAlign = 0.5,
+  tailHeight = 0,
+  closeNose = false,
+  closeTail = false,
+  nosecapLength = 0,
+  tailcapLength = 0,
+  segmentCount = 20,
+  finHeight = 10,
+  finRootChord = 15,
+  finTipChord = 0,
+  finSweep = 0,
+  finThickness = 1,
+  finOffset = 0,
+}) {
+  const body = (
+    <Fuselage
+      length={length}
+      frontWidth={frontWidth}
+      frontHeight={frontHeight}
+      backWidth={backWidth}
+      backHeight={backHeight}
+      cornerRadius={cornerRadius}
+      curveH={curveH}
+      curveV={curveV}
+      verticalAlign={verticalAlign}
+      tailHeight={tailHeight}
+      closeNose={closeNose}
+      closeTail={closeTail}
+      nosecapLength={nosecapLength}
+      tailcapLength={tailcapLength}
+      segmentCount={segmentCount}
+      wireframe={wireframe}
+      debugCrossSections={false}
+      color="silver"
+    />
+  );
+
+  const nacelleMaxHeight = Math.max(frontHeight, backHeight);
+  const finComponent = fin
+    ? (
+        <Rudder
+          height={finHeight}
+          rootChord={finRootChord}
+          tipChord={finTipChord}
+          sweep={finSweep}
+          thickness={finThickness}
+          offset={finOffset}
+          wireframe={wireframe}
+          position={[0, fin === 'top' ? nacelleMaxHeight / 2 : -nacelleMaxHeight / 2, 0]}
+        />
+      )
+    : null;
+
   return (
-    <mesh geometry={geom} position={position} rotation={[Math.PI / 2, 0, 0]}>
-      <meshStandardMaterial color="silver" side={THREE.DoubleSide} wireframe={wireframe} />
-    </mesh>
+    <group position={position}>
+      {body}
+      {finComponent}
+    </group>
   );
 }

--- a/src/components/Wing.jsx
+++ b/src/components/Wing.jsx
@@ -194,8 +194,9 @@ export default function Wing({
   mountZ = 0,
   wireframe = false,
   showNacelles = false,
-  nacelleRadius = 10,
-  nacelleLength = 40,
+  nacelleParams = {},
+  nacelleFlags = [],
+  nacelleFins = [],
 }) {
   const geom = useMemo(() => {
     return createWingGeometry(sections, sweep, mirrored);
@@ -211,26 +212,30 @@ export default function Wing({
         <meshStandardMaterial color="skyblue" side={THREE.DoubleSide} wireframe={wireframe} />
       </mesh>
       {showNacelles &&
-        nacellePositions.map((pos, i) => (
-          <Nacelle
-            key={i}
-            position={pos}
-            radius={nacelleRadius}
-            length={nacelleLength}
-            wireframe={wireframe}
-          />
-        ))}
+        nacellePositions.map((pos, i) =>
+          nacelleFlags[i] ? (
+            <Nacelle
+              key={i}
+              position={pos}
+              wireframe={wireframe}
+              fin={nacelleFins[i]}
+              {...nacelleParams}
+            />
+          ) : null
+        )}
       {showNacelles &&
         mirrored &&
-        nacellePositions.map((pos, i) => (
-          <Nacelle
-            key={`m-${i}`}
-            position={[-pos[0], pos[1], pos[2]]}
-            radius={nacelleRadius}
-            length={nacelleLength}
-            wireframe={wireframe}
-          />
-        ))}
+        nacellePositions.map((pos, i) =>
+          nacelleFlags[i] ? (
+            <Nacelle
+              key={`m-${i}`}
+              position={[-pos[0], pos[1], pos[2]]}
+              wireframe={wireframe}
+              fin={nacelleFins[i]}
+              {...nacelleParams}
+            />
+          ) : null
+        )}
     </group>
   );
 }


### PR DESCRIPTION
## Summary
- Allow enabling a nacelle on individual wing panels with optional top or bottom fins
- Replace cylinder nacelles with fuselage-based geometry sharing fuselage options
- Support custom fuselage color for reuse by nacelles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68952a5915ec8330b69015bd8d2f920a