### PR TITLE
feat: add selectable color themes

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="theme-light">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import AirfoilPreview from './components/AirfoilPreview';
 import ViewControls from './components/ViewControls';
 import Aircraft from './components/Aircraft';
 import MiniView from './components/MiniView';
+import ThemeSwitcher from './components/ThemeSwitcher';
 //
 function ResizeHandler() {
   const { camera, size } = useThree();
@@ -397,6 +398,7 @@ export default function App({ showAirfoilControls = false } = {}) {
 
       {/* Main Content */}
       <div style={{ flex: 1, position: 'relative', height: '100%', overflowY: 'auto' }}>
+        <ThemeSwitcher />
         {showAirfoilControls ? (
           <div style={{ padding: '10px' }}>{previewElements}</div>
         ) : (

--- a/src/components/ThemeSwitcher.jsx
+++ b/src/components/ThemeSwitcher.jsx
@@ -1,0 +1,26 @@
+import React, { useEffect, useState } from 'react';
+
+const themes = ['light', 'dark', 'blue', 'green'];
+
+export default function ThemeSwitcher() {
+  const [theme, setTheme] = useState('light');
+
+  useEffect(() => {
+    const themeClasses = themes.map((t) => `theme-${t}`);
+    const root = document.documentElement;
+    root.classList.remove(...themeClasses);
+    root.classList.add(`theme-${theme}`);
+  }, [theme]);
+
+  return (
+    <div style={{ position: 'absolute', top: 20, right: 20 }}>
+      <select value={theme} onChange={(e) => setTheme(e.target.value)}>
+        {themes.map((t) => (
+          <option key={t} value={t}>
+            {t.charAt(0).toUpperCase() + t.slice(1)}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -3,9 +3,15 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  /* Default (light theme) variables */
+  --text-color: #213547;
+  --bg-color: #ffffff;
+  --link-color: #646cff;
+  --link-hover: #747bff;
+  --button-bg: #f9f9f9;
+
+  color: var(--text-color);
+  background-color: var(--bg-color);
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -13,13 +19,45 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+.theme-light {
+  --text-color: #213547;
+  --bg-color: #ffffff;
+  --link-color: #646cff;
+  --link-hover: #747bff;
+  --button-bg: #f9f9f9;
+}
+
+.theme-dark {
+  --text-color: rgba(255, 255, 255, 0.87);
+  --bg-color: #242424;
+  --link-color: #646cff;
+  --link-hover: #535bf2;
+  --button-bg: #1a1a1a;
+}
+
+.theme-blue {
+  --text-color: #ffffff;
+  --bg-color: #001f3f;
+  --link-color: #7FDBFF;
+  --link-hover: #39CCCC;
+  --button-bg: #0074D9;
+}
+
+.theme-green {
+  --text-color: #e0ffe0;
+  --bg-color: #1a2e1a;
+  --link-color: #2ecc40;
+  --link-hover: #3d9970;
+  --button-bg: #2e8b57;
+}
+
 a {
   font-weight: 500;
-  color: #646cff;
+  color: var(--link-color);
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: var(--link-hover);
 }
 
 body {
@@ -42,27 +80,14 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: var(--button-bg);
   cursor: pointer;
   transition: border-color 0.25s;
 }
 button:hover {
-  border-color: #646cff;
+  border-color: var(--link-color);
 }
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }


### PR DESCRIPTION
## Summary
- add ThemeSwitcher component to choose from four color themes
- define theme CSS variables for light, dark, blue, and green schemes
- set default theme and wire switcher into main app

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895587f0e5c8330946599d05b5dafda