### PR TITLE
Add curved top corners for rudder and fins

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ If you are developing a production application, we recommend using TypeScript wi
 - The rudder now uses the same sweep and chord controls as a wing
   (without mirroring or airfoil support).
 - The rudder can be shifted forward or backward along the fuselage.
+- The front and back top corners of the rudder and nacelle fins can be curved.
 - The fuselage can be hidden entirely if desired.
 - Elevator geometry can now be customized with independent root and tip chords,
   span, sweep, dihedral and airfoil settings.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -165,6 +165,8 @@ export default function App({ showAirfoilControls = false } = {}) {
       finSweep: num(0, { min: -300, max: 300, step: 1, label: 'Fin Sweep' }),
       finThickness: num(1, { min: 0.1, max: 10, step: 0.1, label: 'Fin Thickness' }),
       finOffset: num(0, { min: -100, max: 100, step: 1, label: 'Fin Offset' }),
+      finFrontCornerRadius: num(0, { min: 0, max: 50, step: 1, label: 'Fin Front Top Radius' }),
+      finBackCornerRadius: num(0, { min: 0, max: 50, step: 1, label: 'Fin Back Top Radius' }),
       topFinAngle: num(45, { min: -180, max: 180, step: 1, label: 'Top Fin Angle (°)' }),
       bottomFinAngle: num(-45, { min: -180, max: 180, step: 1, label: 'Bottom Fin Angle (°)' }),
     },
@@ -200,6 +202,8 @@ export default function App({ showAirfoilControls = false } = {}) {
       finSweep: num(0, { min: -300, max: 300, step: 1, label: 'Fin Sweep' }),
       finThickness: num(1, { min: 0.1, max: 10, step: 0.1, label: 'Fin Thickness' }),
       finOffset: num(0, { min: -100, max: 100, step: 1, label: 'Fin Offset' }),
+      finFrontCornerRadius: num(0, { min: 0, max: 50, step: 1, label: 'Fin Front Top Radius' }),
+      finBackCornerRadius: num(0, { min: 0, max: 50, step: 1, label: 'Fin Back Top Radius' }),
       topFinAngle: num(45, { min: -180, max: 180, step: 1, label: 'Top Fin Angle (°)' }),
       bottomFinAngle: num(-45, { min: -180, max: 180, step: 1, label: 'Bottom Fin Angle (°)' }),
     },
@@ -235,6 +239,8 @@ export default function App({ showAirfoilControls = false } = {}) {
       finSweep: num(0, { min: -300, max: 300, step: 1, label: 'Fin Sweep' }),
       finThickness: num(1, { min: 0.1, max: 10, step: 0.1, label: 'Fin Thickness' }),
       finOffset: num(0, { min: -100, max: 100, step: 1, label: 'Fin Offset' }),
+      finFrontCornerRadius: num(0, { min: 0, max: 50, step: 1, label: 'Fin Front Top Radius' }),
+      finBackCornerRadius: num(0, { min: 0, max: 50, step: 1, label: 'Fin Back Top Radius' }),
       topFinAngle: num(45, { min: -180, max: 180, step: 1, label: 'Top Fin Angle (°)' }),
       bottomFinAngle: num(-45, { min: -180, max: 180, step: 1, label: 'Bottom Fin Angle (°)' }),
     },
@@ -257,6 +263,8 @@ export default function App({ showAirfoilControls = false } = {}) {
     rudderSweep,
     rudderThickness,
     rudderOffset,
+    frontCornerRadius,
+    backCornerRadius,
   } = useControls('Rudder', {
     showRudder: false,
     rudderHeight: num(40, { min: 10, max: 100, step: 1, label: 'Height' }),
@@ -265,6 +273,8 @@ export default function App({ showAirfoilControls = false } = {}) {
     rudderSweep: num(0, { min: -300, max: 300, step: 1, label: 'Sweep' }),
     rudderThickness: num(2, { min: 1, max: 10, step: 0.5, label: 'Thickness' }),
     rudderOffset: num(0, { min: -100, max: 100, step: 1, label: 'Offset' }),
+    frontCornerRadius: num(0, { min: 0, max: 50, step: 1, label: 'Front Top Radius' }),
+    backCornerRadius: num(0, { min: 0, max: 50, step: 1, label: 'Back Top Radius' }),
   });
 
   const {
@@ -424,6 +434,8 @@ export default function App({ showAirfoilControls = false } = {}) {
                 rudderSweep={rudderSweep}
                 rudderThickness={rudderThickness}
                 rudderOffset={rudderOffset}
+                frontCornerRadius={frontCornerRadius}
+                backCornerRadius={backCornerRadius}
                 showElevator={showElevator}
                 elevatorRootChord={elevatorRootChord}
                 elevatorTipChord={elevatorTipChord}
@@ -466,9 +478,11 @@ export default function App({ showAirfoilControls = false } = {}) {
                   rudderHeight={rudderHeight}
                   rootChord={rootChord}
                   tipChord={tipChord}
-                  rudderSweep={rudderSweep}
-                  rudderThickness={rudderThickness}
-                  rudderOffset={rudderOffset}
+                rudderSweep={rudderSweep}
+                rudderThickness={rudderThickness}
+                rudderOffset={rudderOffset}
+                frontCornerRadius={frontCornerRadius}
+                backCornerRadius={backCornerRadius}
                 showElevator={showElevator}
                 elevatorRootChord={elevatorRootChord}
                 elevatorTipChord={elevatorTipChord}
@@ -500,9 +514,11 @@ export default function App({ showAirfoilControls = false } = {}) {
                   rudderHeight={rudderHeight}
                   rootChord={rootChord}
                   tipChord={tipChord}
-                  rudderSweep={rudderSweep}
-                  rudderThickness={rudderThickness}
-                  rudderOffset={rudderOffset}
+                rudderSweep={rudderSweep}
+                rudderThickness={rudderThickness}
+                rudderOffset={rudderOffset}
+                frontCornerRadius={frontCornerRadius}
+                backCornerRadius={backCornerRadius}
                 showElevator={showElevator}
                 elevatorRootChord={elevatorRootChord}
                 elevatorTipChord={elevatorTipChord}

--- a/src/components/Aircraft.jsx
+++ b/src/components/Aircraft.jsx
@@ -25,6 +25,8 @@ export default function Aircraft({
   rudderSweep = 0,
   rudderThickness = 2,
   rudderOffset = 0,
+  frontCornerRadius = 0,
+  backCornerRadius = 0,
   showElevator = false,
   elevatorRootChord = 50,
   elevatorTipChord = 50,
@@ -73,6 +75,8 @@ export default function Aircraft({
           sweep={rudderSweep}
           thickness={rudderThickness}
           offset={rudderOffset}
+          frontCornerRadius={frontCornerRadius}
+          backCornerRadius={backCornerRadius}
           wireframe={wireframe}
           position={[
             0,

--- a/src/components/Nacelle.jsx
+++ b/src/components/Nacelle.jsx
@@ -31,6 +31,8 @@ export default function Nacelle({
   finSweep = 0,
   finThickness = 1,
   finOffset = 0,
+  finFrontCornerRadius = 0,
+  finBackCornerRadius = 0,
 }) {
   const body = (
     <Fuselage
@@ -76,6 +78,8 @@ export default function Nacelle({
           sweep={finSweep}
           thickness={finThickness}
           offset={finOffset}
+          frontCornerRadius={finFrontCornerRadius}
+          backCornerRadius={finBackCornerRadius}
           wireframe={wireframe}
           position={[0, topY, 0]}
         />
@@ -92,6 +96,8 @@ export default function Nacelle({
           sweep={finSweep}
           thickness={finThickness}
           offset={finOffset}
+          frontCornerRadius={finFrontCornerRadius}
+          backCornerRadius={finBackCornerRadius}
           wireframe={wireframe}
           position={[0, bottomY, 0]}
           rotation={[Math.PI, 0, 0]}

--- a/src/components/Rudder.jsx
+++ b/src/components/Rudder.jsx
@@ -8,6 +8,8 @@ export default function Rudder({
   sweep = 0,
   thickness = 2,
   offset = 0,
+  frontCornerRadius = 0,
+  backCornerRadius = 0,
   wireframe = false,
   position = [0, 0, 0],
   rotation = [0, 0, 0],
@@ -18,17 +20,42 @@ export default function Rudder({
     const lead = (t) => sweep * t;
     const trail = (t) => rootChord + (sweep + tipChord - rootChord) * t;
 
+    let fcr = Math.max(0, frontCornerRadius);
+    let bcr = Math.max(0, backCornerRadius);
+    const topWidth = trail(1) - lead(1);
+    if (bcr > topWidth) bcr = topWidth;
+    if (fcr > topWidth - bcr) fcr = topWidth - bcr;
+    const limitedFcr = Math.min(fcr, height);
+    const limitedBcr = Math.min(bcr, height);
+
     shape.moveTo(lead(0), 0);
     shape.lineTo(trail(0), 0);
-    shape.lineTo(trail(1), height);
-    shape.lineTo(lead(1), height);
+    shape.lineTo(trail(1), height - limitedBcr);
+    if (limitedBcr)
+      shape.quadraticCurveTo(
+        trail(1),
+        height,
+        trail(1) - limitedBcr,
+        height,
+      );
+    else shape.lineTo(trail(1), height);
+    shape.lineTo(lead(1) + limitedFcr, height);
+    if (limitedFcr)
+      shape.quadraticCurveTo(
+        lead(1),
+        height,
+        lead(1),
+        height - limitedFcr,
+      );
+    else shape.lineTo(lead(1), height);
+    shape.lineTo(lead(0), 0);
     shape.closePath();
 
     const g = new THREE.ExtrudeGeometry(shape, { depth: thickness, bevelEnabled: false });
     g.rotateY(Math.PI / 2);
     g.translate(-thickness / 2, 0, 0);
     return g;
-  }, [height, rootChord, tipChord, sweep, thickness]);
+  }, [height, rootChord, tipChord, sweep, thickness, frontCornerRadius, backCornerRadius]);
 
   const finalPos = [position[0], position[1], position[2] + offset];
 


### PR DESCRIPTION
## Summary
- Allow rudder shape to round its front and back top corners via new radii
- Forward corner radius controls to nacelle fins and aircraft rudder
- Add Leva controls for adjusting new corner radii

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895580414fc8330829c72480444737f