### PR TITLE
Expand theme switcher to whole UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useState } from 'react';
 import { Canvas, useThree } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
 import { useControls, Leva } from 'leva';
@@ -14,6 +14,51 @@ import ViewControls from './components/ViewControls';
 import Aircraft from './components/Aircraft';
 import MiniView from './components/MiniView';
 import ThemeSwitcher from './components/ThemeSwitcher';
+
+const themeList = ['light', 'dark', 'blue', 'green'];
+
+const levaThemes = {
+  light: {
+    colors: {
+      elevation1: '#ffffff',
+      elevation2: '#f0f0f0',
+      highlight1: '#007acc',
+      accent1: '#007acc',
+      accent2: '#005f99',
+      text: '#1a1a1a',
+    },
+  },
+  dark: {
+    colors: {
+      elevation1: '#1e1e1e',
+      elevation2: '#333333',
+      highlight1: '#66aaff',
+      accent1: '#66aaff',
+      accent2: '#99ccff',
+      text: '#e0e0e0',
+    },
+  },
+  blue: {
+    colors: {
+      elevation1: '#003f5c',
+      elevation2: '#005f7f',
+      highlight1: '#00bfff',
+      accent1: '#00bfff',
+      accent2: '#80dfff',
+      text: '#e0f7ff',
+    },
+  },
+  green: {
+    colors: {
+      elevation1: '#1b3b2f',
+      elevation2: '#2e8b57',
+      highlight1: '#2ecc71',
+      accent1: '#2ecc71',
+      accent2: '#27ae60',
+      text: '#e9f7ef',
+    },
+  },
+};
 //
 function ResizeHandler() {
   const { camera, size } = useThree();
@@ -40,6 +85,15 @@ function CameraCenter({ controlsRef, targetGroup }) {
 }
 // Trigger rebuild
 export default function App({ showAirfoilControls = false } = {}) {
+  const [theme, setTheme] = useState('light');
+
+  useEffect(() => {
+    const themeClasses = themeList.map((t) => `theme-${t}`);
+    const root = document.documentElement;
+    root.classList.remove(...themeClasses);
+    root.classList.add(`theme-${theme}`);
+  }, [theme]);
+
   const controlsRef = useRef();
   const groupRef = useRef();
   const {
@@ -399,16 +453,12 @@ export default function App({ showAirfoilControls = false } = {}) {
         borderRight: '1px solid #333',
         overflowY: 'auto'
       }}>
-        <Leva
-          collapsed={false}
-          fill
-          theme={{ colors: { elevation1: '#d1ebeb' } }}
-        />
+        <Leva collapsed={false} fill theme={levaThemes[theme]} />
       </div>
 
       {/* Main Content */}
       <div style={{ flex: 1, position: 'relative', height: '100%', overflowY: 'auto' }}>
-        <ThemeSwitcher />
+        <ThemeSwitcher theme={theme} setTheme={setTheme} themes={themeList} />
         {showAirfoilControls ? (
           <div style={{ padding: '10px' }}>{previewElements}</div>
         ) : (

--- a/src/components/ThemeSwitcher.jsx
+++ b/src/components/ThemeSwitcher.jsx
@@ -1,17 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 
-const themes = ['light', 'dark', 'blue', 'green'];
-
-export default function ThemeSwitcher() {
-  const [theme, setTheme] = useState('light');
-
-  useEffect(() => {
-    const themeClasses = themes.map((t) => `theme-${t}`);
-    const root = document.documentElement;
-    root.classList.remove(...themeClasses);
-    root.classList.add(`theme-${theme}`);
-  }, [theme]);
-
+export default function ThemeSwitcher({ theme, setTheme, themes }) {
   return (
     <div style={{ position: 'absolute', top: 20, right: 20 }}>
       <select value={theme} onChange={(e) => setTheme(e.target.value)}>

--- a/src/index.css
+++ b/src/index.css
@@ -4,11 +4,11 @@
   font-weight: 400;
 
   /* Default (light theme) variables */
-  --text-color: #213547;
+  --text-color: #1a1a1a;
   --bg-color: #ffffff;
-  --link-color: #646cff;
-  --link-hover: #747bff;
-  --button-bg: #f9f9f9;
+  --link-color: #007acc;
+  --link-hover: #005f99;
+  --button-bg: #f0f0f0;
 
   color: var(--text-color);
   background-color: var(--bg-color);
@@ -20,34 +20,34 @@
 }
 
 .theme-light {
-  --text-color: #213547;
+  --text-color: #1a1a1a;
   --bg-color: #ffffff;
-  --link-color: #646cff;
-  --link-hover: #747bff;
-  --button-bg: #f9f9f9;
+  --link-color: #007acc;
+  --link-hover: #005f99;
+  --button-bg: #f0f0f0;
 }
 
 .theme-dark {
-  --text-color: rgba(255, 255, 255, 0.87);
-  --bg-color: #242424;
-  --link-color: #646cff;
-  --link-hover: #535bf2;
-  --button-bg: #1a1a1a;
+  --text-color: #e0e0e0;
+  --bg-color: #1e1e1e;
+  --link-color: #66aaff;
+  --link-hover: #99ccff;
+  --button-bg: #333333;
 }
 
 .theme-blue {
-  --text-color: #ffffff;
-  --bg-color: #001f3f;
-  --link-color: #7FDBFF;
-  --link-hover: #39CCCC;
-  --button-bg: #0074D9;
+  --text-color: #e0f7ff;
+  --bg-color: #003f5c;
+  --link-color: #00bfff;
+  --link-hover: #80dfff;
+  --button-bg: #005f7f;
 }
 
 .theme-green {
-  --text-color: #e0ffe0;
-  --bg-color: #1a2e1a;
-  --link-color: #2ecc40;
-  --link-hover: #3d9970;
+  --text-color: #e9f7ef;
+  --bg-color: #1b3b2f;
+  --link-color: #2ecc71;
+  --link-hover: #27ae60;
   --button-bg: #2e8b57;
 }
 


### PR DESCRIPTION
## Summary
- Extend theme state to cover entire application and Leva controls
- Introduce cohesive light, dark, blue, and green color palettes
- Wire ThemeSwitcher to propagate selected theme through UI and sliders

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68955db8835c8330a4d84caecf7df503