### PR TITLE
fix: make theme switcher clickable

### DIFF
--- a/src/components/ThemeSwitcher.jsx
+++ b/src/components/ThemeSwitcher.jsx
@@ -2,7 +2,14 @@ import React from 'react';
 
 export default function ThemeSwitcher({ theme, setTheme, themes }) {
   return (
-    <div style={{ position: 'absolute', top: 20, right: 20 }}>
+    <div
+      style={{
+        position: 'absolute',
+        top: 20,
+        right: 20,
+        zIndex: 1000,
+      }}
+    >
       <select value={theme} onChange={(e) => setTheme(e.target.value)}>
         {themes.map((t) => (
           <option key={t} value={t}>


### PR DESCRIPTION
## Summary
- ensure theme switcher sits above canvas for interaction by adding a high z-index

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895676cf3a48330af3d299c24f62c60