### PR TITLE
feat: add supabase auth and design storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_SUPABASE_URL=https://your-supabase-url.supabase.co
+VITE_SUPABASE_ANON_KEY=public-anon-key

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@react-three/drei": "^10.5.1",
         "@react-three/fiber": "^9.2.0",
+        "@supabase/supabase-js": "^2.54.0",
         "leva": "^0.10.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -1535,6 +1536,80 @@
         "react": ">= 16.3.0"
       }
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.71.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
+      "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.5.tgz",
+      "integrity": "sha512-v5GSqb9zbosquTo6gBwIiq7W9eQ7rE5QazsK/ezNiQXdCbY+bH8D9qEaBIkhVvX4ZRW5rP03gEfw5yw9tiq4EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.19.4.tgz",
+      "integrity": "sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.0.tgz",
+      "integrity": "sha512-SEIWApsxyoAe68WU2/5PCCuBwa11LL4Bb8K3r2FHCt3ROpaTthmDiWEhnLMGayP05N4QeYrMk0kyTZOwid/Hjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.10.4",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.10.4.tgz",
+      "integrity": "sha512-cvL02GarJVFcNoWe36VBybQqTVRq6wQSOCvTS64C+eyuxOruFIm1utZAY0xi2qKtHJO3EjKaj8iWJKySusDmAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.54.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.54.0.tgz",
+      "integrity": "sha512-DLw83YwBfAaFiL3oWV26+sHRdeCGtxmIKccjh/Pndze3BWM4fZghzYKhk3ElOQU8Bluq4AkkCJ5bM5Szl/sfRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.71.1",
+        "@supabase/functions-js": "2.4.5",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.19.4",
+        "@supabase/realtime-js": "2.15.0",
+        "@supabase/storage-js": "^2.10.4"
+      }
+    },
     "node_modules/@tweenjs/tween.js": {
       "version": "23.1.3",
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
@@ -1606,10 +1681,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.0.tgz",
+      "integrity": "sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
     "node_modules/@types/offscreencanvas": {
       "version": "2019.7.3",
       "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
       "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
       "license": "MIT"
     },
     "node_modules/@types/react": {
@@ -1666,6 +1756,15 @@
       "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.22.tgz",
       "integrity": "sha512-Vr6Stjv5jPRqH690f5I5GLjVk8GSsoQSYJ2FVd/3jJF7KaqfwPi3ehfBS96mlQ2kPCwZaX6U0rG2+NGHBKkA/A==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@use-gesture/core": {
       "version": "10.3.1",
@@ -4392,6 +4491,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/trim-repeated": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
@@ -4500,6 +4605,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "2.0.1",
@@ -4686,6 +4797,22 @@
       "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
       "license": "MIT"
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4709,6 +4836,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@react-three/drei": "^10.5.1",
     "@react-three/fiber": "^9.2.0",
+    "@supabase/supabase-js": "^2.54.0",
     "leva": "^0.10.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/auth/AuthContext.jsx
+++ b/src/auth/AuthContext.jsx
@@ -1,0 +1,55 @@
+/* eslint-disable react-refresh/only-export-components */
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { supabase } from '../lib/supabaseClient.js';
+
+const AuthContext = createContext();
+
+export function AuthProvider({ children }) {
+  const [session, setSession] = useState(null);
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const init = async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      setSession(session);
+      setUser(session?.user ?? null);
+      setLoading(false);
+    };
+    init();
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(session);
+      setUser(session?.user ?? null);
+      setLoading(false);
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  const value = {
+    session,
+    user,
+    loading,
+    signInWithEmail: (email, password) =>
+      supabase.auth.signInWithPassword({ email, password }),
+    signUpWithEmail: (email, password) =>
+      supabase.auth.signUp({ email, password }),
+    signInWithOAuth: (provider) => supabase.auth.signInWithOAuth({ provider }),
+    signOut: () => supabase.auth.signOut(),
+  };
+
+  return (
+    <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  return useContext(AuthContext);
+}

--- a/src/auth/AuthModal.jsx
+++ b/src/auth/AuthModal.jsx
@@ -1,0 +1,91 @@
+import React, { useState } from 'react';
+import { useAuth } from './AuthContext.jsx';
+
+export default function AuthModal({ open, onClose }) {
+  const { signInWithEmail, signUpWithEmail, signInWithOAuth } = useAuth();
+  const [tab, setTab] = useState('signin');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(null);
+
+  if (!open) return null;
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    const fn = tab === 'signin' ? signInWithEmail : signUpWithEmail;
+    const { error } = await fn(email, password);
+    if (error) setError(error.message);
+    else onClose();
+  };
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.5)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <div style={{ background: '#fff', padding: '1rem', width: '300px', position: 'relative' }}>
+        <div style={{ display: 'flex', marginBottom: '1rem' }}>
+          <button
+            type="button"
+            onClick={() => setTab('signin')}
+            disabled={tab === 'signin'}
+            style={{ flex: 1 }}
+          >
+            Sign In
+          </button>
+          <button
+            type="button"
+            onClick={() => setTab('signup')}
+            disabled={tab === 'signup'}
+            style={{ flex: 1 }}
+          >
+            Create Account
+          </button>
+        </div>
+        <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+          <input
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+          <input
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+          {error && <div style={{ color: 'red' }}>{error}</div>}
+          <button type="submit">{tab === 'signin' ? 'Sign In' : 'Sign Up'}</button>
+        </form>
+        <div style={{ margin: '1rem 0', textAlign: 'center' }}>or</div>
+        <button
+          type="button"
+          onClick={() => signInWithOAuth('github')}
+          style={{ width: '100%', marginBottom: '0.5rem' }}
+        >
+          Sign in with GitHub
+        </button>
+        <button type="button" onClick={() => signInWithOAuth('google')} style={{ width: '100%' }}>
+          Sign in with Google
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          style={{ position: 'absolute', top: '0.25rem', right: '0.25rem' }}
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/auth/RequireAuth.jsx
+++ b/src/auth/RequireAuth.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { useAuth } from './AuthContext.jsx';
+
+export default function RequireAuth({ children, onOpenAuth }) {
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return <div style={{ textAlign: 'center', padding: '2rem' }}>Loading...</div>;
+  }
+
+  if (!user) {
+    return (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: '100%',
+          gap: '1rem',
+        }}
+      >
+        <p>Sign in to continue</p>
+        <button type="button" onClick={onOpenAuth}>
+          Sign in
+        </button>
+      </div>
+    );
+  }
+
+  return children;
+}

--- a/src/components/DesignFlow.jsx
+++ b/src/components/DesignFlow.jsx
@@ -3,16 +3,112 @@ import TemplateStep from './steps/TemplateStep.jsx';
 import BuildStep from './steps/BuildStep.jsx';
 import AirfoilStep from './steps/AirfoilStep.jsx';
 import ExportStep from './steps/ExportStep.jsx';
+import AuthModal from '../auth/AuthModal.jsx';
+import { useAuth } from '../auth/AuthContext.jsx';
+import { createDesign, deleteDesign, listDesigns, updateDesign } from '../data/designsApi.js';
 
-const steps = [
-  { label: 'Templates', component: <TemplateStep /> },
-  { label: 'Build', component: <BuildStep /> },
-  { label: 'Airfoils', component: <AirfoilStep /> },
-  { label: 'Export', component: <ExportStep /> },
-];
+function UserMenu({ email, onSignOut, onShowDesigns }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div style={{ position: 'relative' }}>
+      <button type="button" onClick={() => setOpen((o) => !o)}>
+        {email}
+      </button>
+      {open && (
+        <div
+          style={{
+            position: 'absolute',
+            right: 0,
+            background: '#fff',
+            color: '#000',
+            border: '1px solid #ccc',
+            minWidth: '150px',
+            zIndex: 20,
+          }}
+        >
+          <button
+            type="button"
+            onClick={() => {
+              onShowDesigns();
+              setOpen(false);
+            }}
+            style={{ width: '100%', padding: '0.5rem', textAlign: 'left' }}
+          >
+            My Designs
+          </button>
+          <button
+            type="button"
+            onClick={onSignOut}
+            style={{ width: '100%', padding: '0.5rem', textAlign: 'left' }}
+          >
+            Sign out
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
 
 export default function DesignFlow() {
   const [current, setCurrent] = useState(0);
+  const { user, signOut } = useAuth();
+  const [showAuth, setShowAuth] = useState(false);
+  const [currentDesignId, setCurrentDesignId] = useState(null);
+  const [designs, setDesigns] = useState([]);
+  const [showLoad, setShowLoad] = useState(false);
+
+  const handleSave = async (data) => {
+    if (!user) return;
+    if (currentDesignId) {
+      await updateDesign(currentDesignId, { data });
+    } else {
+      await handleSaveAs(data);
+    }
+  };
+
+  const handleSaveAs = async (data) => {
+    if (!user) return;
+    const name = window.prompt('Design name');
+    if (!name) return;
+    const row = await createDesign({ name, data });
+    setCurrentDesignId(row.id);
+  };
+
+  const openLoad = async () => {
+    const list = await listDesigns();
+    setDesigns(list);
+    setShowLoad(true);
+  };
+
+  const loadDesign = (design) => {
+    setCurrentDesignId(design.id);
+    setShowLoad(false);
+    // design.data not applied; placeholder for future use
+  };
+
+  const steps = [
+    { label: 'Templates', component: <TemplateStep /> },
+    {
+      label: 'Build',
+      component: (
+        <BuildStep onSave={handleSave} onSaveAs={handleSaveAs} onLoad={openLoad} />
+      ),
+    },
+    {
+      label: 'Airfoils',
+      component: (
+        <AirfoilStep
+          onSave={handleSave}
+          onSaveAs={handleSaveAs}
+          onLoad={openLoad}
+        />
+      ),
+    },
+    {
+      label: 'Export',
+      component: <ExportStep onOpenAuth={() => setShowAuth(true)} />,
+    },
+  ];
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
@@ -24,36 +120,97 @@ export default function DesignFlow() {
           borderBottom: '1px solid #333',
         }}
       >
-        <ul
-          style={{
-            display: 'flex',
-            listStyle: 'none',
-            padding: 0,
-            margin: 0,
-            gap: '1rem',
-          }}
-        >
-          {steps.map((step, index) => (
-            <li key={step.label} style={{ flex: 1 }}>
-              <button
-                type="button"
-                onClick={() => setCurrent(index)}
-                style={{
-                  width: '100%',
-                  padding: '0.75rem',
-                  background: current === index ? '#646cff' : '#333',
-                  color: 'inherit',
-                  border: 'none',
-                  cursor: 'pointer',
-                }}
-              >
-                {step.label}
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          <ul
+            style={{
+              display: 'flex',
+              listStyle: 'none',
+              padding: 0,
+              margin: 0,
+              gap: '1rem',
+              flex: 1,
+            }}
+          >
+            {steps.map((step, index) => (
+              <li key={step.label} style={{ flex: 1 }}>
+                <button
+                  type="button"
+                  onClick={() => setCurrent(index)}
+                  style={{
+                    width: '100%',
+                    padding: '0.75rem',
+                    background: current === index ? '#646cff' : '#333',
+                    color: 'inherit',
+                    border: 'none',
+                    cursor: 'pointer',
+                  }}
+                >
+                  {step.label}
+                </button>
+              </li>
+            ))}
+          </ul>
+          <div style={{ marginLeft: '1rem', position: 'relative' }}>
+            {user ? (
+              <UserMenu
+                email={user.email}
+                onSignOut={signOut}
+                onShowDesigns={openLoad}
+              />
+            ) : (
+              <button type="button" onClick={() => setShowAuth(true)}>
+                Sign in
               </button>
-            </li>
-          ))}
-        </ul>
+            )}
+          </div>
+        </div>
       </header>
       <div style={{ flex: 1, overflow: 'auto' }}>{steps[current].component}</div>
+      <AuthModal open={showAuth} onClose={() => setShowAuth(false)} />
+      {showLoad && (
+        <div
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'rgba(0,0,0,0.5)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <div style={{ background: '#fff', padding: '1rem', width: '300px' }}>
+            <h3>My Designs</h3>
+            <ul style={{ listStyle: 'none', padding: 0 }}>
+              {designs.map((d) => (
+                <li
+                  key={d.id}
+                  style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.5rem' }}
+                >
+                  <button
+                    type="button"
+                    onClick={() => loadDesign(d)}
+                    style={{ flex: 1, textAlign: 'left' }}
+                  >
+                    {d.name}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={async () => {
+                      await deleteDesign(d.id);
+                      setDesigns(designs.filter((x) => x.id !== d.id));
+                    }}
+                  >
+                    X
+                  </button>
+                </li>
+              ))}
+            </ul>
+            <button type="button" onClick={() => setShowLoad(false)} style={{ marginTop: '1rem' }}>
+              Close
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/steps/AirfoilStep.jsx
+++ b/src/components/steps/AirfoilStep.jsx
@@ -1,6 +1,25 @@
 import React from 'react';
 import DesignApp from '../../App.jsx';
+import { useAuth } from '../../auth/AuthContext.jsx';
 
-export default function AirfoilStep() {
-  return <DesignApp showAirfoilControls />;
+export default function AirfoilStep({ onSave, onSaveAs, onLoad }) {
+  const { user } = useAuth();
+  return (
+    <div>
+      {user && (
+        <div style={{ padding: '0.5rem', display: 'flex', gap: '0.5rem' }}>
+          <button type="button" onClick={() => onSave({})} disabled={!user}>
+            Save
+          </button>
+          <button type="button" onClick={() => onSaveAs({})} disabled={!user}>
+            Save as…
+          </button>
+          <button type="button" onClick={onLoad} disabled={!user}>
+            Load
+          </button>
+        </div>
+      )}
+      <DesignApp showAirfoilControls />
+    </div>
+  );
 }

--- a/src/components/steps/BuildStep.jsx
+++ b/src/components/steps/BuildStep.jsx
@@ -1,6 +1,25 @@
 import React from 'react';
 import DesignApp from '../../App.jsx';
+import { useAuth } from '../../auth/AuthContext.jsx';
 
-export default function BuildStep() {
-  return <DesignApp showAirfoilControls={false} />;
+export default function BuildStep({ onSave, onSaveAs, onLoad }) {
+  const { user } = useAuth();
+  return (
+    <div>
+      {user && (
+        <div style={{ padding: '0.5rem', display: 'flex', gap: '0.5rem' }}>
+          <button type="button" onClick={() => onSave({})} disabled={!user}>
+            Save
+          </button>
+          <button type="button" onClick={() => onSaveAs({})} disabled={!user}>
+            Save as…
+          </button>
+          <button type="button" onClick={onLoad} disabled={!user}>
+            Load
+          </button>
+        </div>
+      )}
+      <DesignApp showAirfoilControls={false} />
+    </div>
+  );
 }

--- a/src/components/steps/ExportStep.jsx
+++ b/src/components/steps/ExportStep.jsx
@@ -1,6 +1,12 @@
 import React from 'react';
+import { useAuth } from '../../auth/AuthContext.jsx';
+import RequireAuth from '../../auth/RequireAuth.jsx';
 
-export default function ExportStep() {
+export default function ExportStep({ onOpenAuth }) {
+  const { user } = useAuth();
+  if (!user) {
+    return <RequireAuth onOpenAuth={onOpenAuth}> </RequireAuth>;
+  }
   return (
     <div style={{ padding: '20px' }}>
       <h2>Export</h2>

--- a/src/data/designsApi.js
+++ b/src/data/designsApi.js
@@ -1,0 +1,39 @@
+import { supabase } from '../lib/supabaseClient.js';
+
+export async function listDesigns() {
+  const { data, error } = await supabase
+    .from('designs')
+    .select('*')
+    .order('updated_at', { ascending: false });
+  if (error) throw error;
+  return data;
+}
+
+export async function createDesign({ name, data }) {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  const { data: row, error } = await supabase
+    .from('designs')
+    .insert({ name, data, user_id: user.id })
+    .select()
+    .single();
+  if (error) throw error;
+  return row;
+}
+
+export async function updateDesign(id, { name, data }) {
+  const { data: row, error } = await supabase
+    .from('designs')
+    .update({ name, data })
+    .eq('id', id)
+    .select()
+    .single();
+  if (error) throw error;
+  return row;
+}
+
+export async function deleteDesign(id) {
+  const { error } = await supabase.from('designs').delete().eq('id', id);
+  if (error) throw error;
+}

--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+export const supabase = createClient(
+  import.meta.env.VITE_SUPABASE_URL,
+  import.meta.env.VITE_SUPABASE_ANON_KEY
+);

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import DesignFlow from './components/DesignFlow.jsx'
+import { AuthProvider } from './auth/AuthContext.jsx'
 //gggggggg
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <DesignFlow />
+    <AuthProvider>
+      <DesignFlow />
+    </AuthProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- integrate Supabase client and auth context
- add sign-in modal, user menu, and protected export step
- stub design save/load API and UI controls

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895684c0d448330919b083691a00c7b