### PR TITLE
Fix design saving missing parameters

### DIFF
--- a/src/components/steps/AirfoilStep.jsx
+++ b/src/components/steps/AirfoilStep.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import DesignApp from '../../App.jsx';
 import { useAuth } from '../../auth/AuthContext.jsx';
+import { getDesignState } from '../../lib/designState.js';
 
 export default function AirfoilStep({ onSave, onSaveAs, onLoad }) {
   const { user } = useAuth();
@@ -8,10 +9,18 @@ export default function AirfoilStep({ onSave, onSaveAs, onLoad }) {
     <div>
       {user && (
         <div style={{ padding: '0.5rem', display: 'flex', gap: '0.5rem' }}>
-          <button type="button" onClick={() => onSave({})} disabled={!user}>
+          <button
+            type="button"
+            onClick={() => onSave(getDesignState())}
+            disabled={!user}
+          >
             Save
           </button>
-          <button type="button" onClick={() => onSaveAs({})} disabled={!user}>
+          <button
+            type="button"
+            onClick={() => onSaveAs(getDesignState())}
+            disabled={!user}
+          >
             Save as…
           </button>
           <button type="button" onClick={onLoad} disabled={!user}>

--- a/src/components/steps/BuildStep.jsx
+++ b/src/components/steps/BuildStep.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import DesignApp from '../../App.jsx';
 import { useAuth } from '../../auth/AuthContext.jsx';
+import { getDesignState } from '../../lib/designState.js';
 
 export default function BuildStep({ onSave, onSaveAs, onLoad }) {
   const { user } = useAuth();
@@ -8,10 +9,18 @@ export default function BuildStep({ onSave, onSaveAs, onLoad }) {
     <div>
       {user && (
         <div style={{ padding: '0.5rem', display: 'flex', gap: '0.5rem' }}>
-          <button type="button" onClick={() => onSave({})} disabled={!user}>
+          <button
+            type="button"
+            onClick={() => onSave(getDesignState())}
+            disabled={!user}
+          >
             Save
           </button>
-          <button type="button" onClick={() => onSaveAs({})} disabled={!user}>
+          <button
+            type="button"
+            onClick={() => onSaveAs(getDesignState())}
+            disabled={!user}
+          >
             Save as…
           </button>
           <button type="button" onClick={onLoad} disabled={!user}>

--- a/src/lib/designState.js
+++ b/src/lib/designState.js
@@ -1,0 +1,10 @@
+import { levaStore } from 'leva';
+
+export function getDesignState() {
+  const data = levaStore.getData();
+  const values = {};
+  Object.entries(data).forEach(([key, entry]) => {
+    values[key] = entry.value;
+  });
+  return values;
+}


### PR DESCRIPTION
## Summary
- capture current Leva control values when saving designs
- add helper for retrieving design state from Leva store

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895732908c08330adf066bc771c2d05