### PR TITLE
Enable loading saved design parameters

### DIFF
--- a/src/components/DesignFlow.jsx
+++ b/src/components/DesignFlow.jsx
@@ -6,6 +6,7 @@ import ExportStep from './steps/ExportStep.jsx';
 import AuthModal from '../auth/AuthModal.jsx';
 import { useAuth } from '../auth/AuthContext.jsx';
 import { createDesign, deleteDesign, listDesigns, updateDesign } from '../data/designsApi.js';
+import { setDesignState } from '../lib/designState.js';
 
 function UserMenu({ email, onSignOut, onShowDesigns }) {
   const [open, setOpen] = useState(false);
@@ -83,7 +84,7 @@ export default function DesignFlow() {
   const loadDesign = (design) => {
     setCurrentDesignId(design.id);
     setShowLoad(false);
-    // design.data not applied; placeholder for future use
+    setDesignState(design.data);
   };
 
   const steps = [

--- a/src/lib/designState.js
+++ b/src/lib/designState.js
@@ -8,3 +8,14 @@ export function getDesignState() {
   });
   return values;
 }
+
+export function setDesignState(values) {
+  if (!values) return;
+  Object.entries(values).forEach(([key, value]) => {
+    try {
+      levaStore.setValueAtPath(key, value);
+    } catch {
+      /* ignore missing paths */
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add setDesignState to populate Leva controls from saved design values
- apply saved values when loading a design

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689577d2de988330b355ce7a20057204