### PR TITLE
Add design thumbnails and template sections

### DIFF
--- a/src/components/DesignFlow.jsx
+++ b/src/components/DesignFlow.jsx
@@ -57,20 +57,20 @@ export default function DesignFlow() {
   const [designs, setDesigns] = useState([]);
   const [showLoad, setShowLoad] = useState(false);
 
-  const handleSave = async (data) => {
+  const handleSave = async ({ data, thumbnail }) => {
     if (!user) return;
     if (currentDesignId) {
-      await updateDesign(currentDesignId, { data });
+      await updateDesign(currentDesignId, { data, thumbnail });
     } else {
-      await handleSaveAs(data);
+      await handleSaveAs({ data, thumbnail });
     }
   };
 
-  const handleSaveAs = async (data) => {
+  const handleSaveAs = async ({ data, thumbnail }) => {
     if (!user) return;
     const name = window.prompt('Design name');
     if (!name) return;
-    const row = await createDesign({ name, data });
+    const row = await createDesign({ name, data, thumbnail });
     setCurrentDesignId(row.id);
   };
 
@@ -184,8 +184,20 @@ export default function DesignFlow() {
               {designs.map((d) => (
                 <li
                   key={d.id}
-                  style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.5rem' }}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    marginBottom: '0.5rem',
+                    gap: '0.5rem',
+                  }}
                 >
+                  {d.thumbnail && (
+                    <img
+                      src={d.thumbnail}
+                      alt={d.name}
+                      style={{ width: '40px', height: '40px', objectFit: 'cover' }}
+                    />
+                  )}
                   <button
                     type="button"
                     onClick={() => loadDesign(d)}

--- a/src/components/TemplateStep.jsx
+++ b/src/components/TemplateStep.jsx
@@ -4,7 +4,18 @@ export default function TemplateStep() {
   return (
     <div>
       <h2>Templates</h2>
-      <p>Select a predefined aircraft layout to start your design.</p>
+      <section>
+        <h3>Personal</h3>
+        <p>Your saved templates will appear here.</p>
+      </section>
+      <section>
+        <h3>Public</h3>
+        <p>Explore templates shared by the community.</p>
+      </section>
+      <section>
+        <h3>Basic</h3>
+        <p>Start from a simple preset.</p>
+      </section>
     </div>
   );
 }

--- a/src/components/steps/AirfoilStep.jsx
+++ b/src/components/steps/AirfoilStep.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import DesignApp from '../../App.jsx';
 import { useAuth } from '../../auth/AuthContext.jsx';
-import { getDesignState } from '../../lib/designState.js';
+import { getDesignState, getDesignThumbnail } from '../../lib/designState.js';
 
 export default function AirfoilStep({ onSave, onSaveAs, onLoad }) {
   const { user } = useAuth();
@@ -11,14 +11,18 @@ export default function AirfoilStep({ onSave, onSaveAs, onLoad }) {
         <div style={{ padding: '0.5rem', display: 'flex', gap: '0.5rem' }}>
           <button
             type="button"
-            onClick={() => onSave(getDesignState())}
+            onClick={() =>
+              onSave({ data: getDesignState(), thumbnail: getDesignThumbnail() })
+            }
             disabled={!user}
           >
             Save
           </button>
           <button
             type="button"
-            onClick={() => onSaveAs(getDesignState())}
+            onClick={() =>
+              onSaveAs({ data: getDesignState(), thumbnail: getDesignThumbnail() })
+            }
             disabled={!user}
           >
             Save as…

--- a/src/components/steps/BuildStep.jsx
+++ b/src/components/steps/BuildStep.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import DesignApp from '../../App.jsx';
 import { useAuth } from '../../auth/AuthContext.jsx';
-import { getDesignState } from '../../lib/designState.js';
+import { getDesignState, getDesignThumbnail } from '../../lib/designState.js';
 
 export default function BuildStep({ onSave, onSaveAs, onLoad }) {
   const { user } = useAuth();
@@ -11,14 +11,18 @@ export default function BuildStep({ onSave, onSaveAs, onLoad }) {
         <div style={{ padding: '0.5rem', display: 'flex', gap: '0.5rem' }}>
           <button
             type="button"
-            onClick={() => onSave(getDesignState())}
+            onClick={() =>
+              onSave({ data: getDesignState(), thumbnail: getDesignThumbnail() })
+            }
             disabled={!user}
           >
             Save
           </button>
           <button
             type="button"
-            onClick={() => onSaveAs(getDesignState())}
+            onClick={() =>
+              onSaveAs({ data: getDesignState(), thumbnail: getDesignThumbnail() })
+            }
             disabled={!user}
           >
             Save as…

--- a/src/components/steps/TemplateStep.jsx
+++ b/src/components/steps/TemplateStep.jsx
@@ -4,7 +4,18 @@ export default function TemplateStep() {
   return (
     <div style={{ padding: '20px' }}>
       <h2>Templates</h2>
-      <p>Select a predefined aircraft layout to start your design.</p>
+      <section>
+        <h3>Personal</h3>
+        <p>Your saved templates will appear here.</p>
+      </section>
+      <section>
+        <h3>Public</h3>
+        <p>Explore templates shared by the community.</p>
+      </section>
+      <section>
+        <h3>Basic</h3>
+        <p>Start from a simple preset.</p>
+      </section>
     </div>
   );
 }

--- a/src/data/designsApi.js
+++ b/src/data/designsApi.js
@@ -9,23 +9,23 @@ export async function listDesigns() {
   return data;
 }
 
-export async function createDesign({ name, data }) {
+export async function createDesign({ name, data, thumbnail }) {
   const {
     data: { user },
   } = await supabase.auth.getUser();
   const { data: row, error } = await supabase
     .from('designs')
-    .insert({ name, data, user_id: user.id })
+    .insert({ name, data, thumbnail, user_id: user.id })
     .select()
     .single();
   if (error) throw error;
   return row;
 }
 
-export async function updateDesign(id, { name, data }) {
+export async function updateDesign(id, { name, data, thumbnail }) {
   const { data: row, error } = await supabase
     .from('designs')
-    .update({ name, data })
+    .update({ name, data, thumbnail })
     .eq('id', id)
     .select()
     .single();

--- a/src/design/TemplateStep.jsx
+++ b/src/design/TemplateStep.jsx
@@ -4,7 +4,18 @@ export default function TemplateStep() {
   return (
     <div style={{ padding: '2rem' }}>
       <h2>Templates</h2>
-      <p>Choose a predefined aircraft layout.</p>
+      <section>
+        <h3>Personal</h3>
+        <p>Your saved templates will appear here.</p>
+      </section>
+      <section>
+        <h3>Public</h3>
+        <p>Explore templates shared by the community.</p>
+      </section>
+      <section>
+        <h3>Basic</h3>
+        <p>Start from a simple preset.</p>
+      </section>
     </div>
   );
 }

--- a/src/lib/designState.js
+++ b/src/lib/designState.js
@@ -8,3 +8,13 @@ export function getDesignState() {
   });
   return values;
 }
+
+export function getDesignThumbnail() {
+  const canvas = document.querySelector('canvas');
+  if (!canvas) return null;
+  try {
+    return canvas.toDataURL('image/png');
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Capture design canvas to generate thumbnails for saved designs
- Save and display thumbnails in My Designs modal
- Add Personal, Public, and Basic sections to templates

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689579191a048330ac5b0e6ab0f81850