### PR TITLE
Smooth rudder corner rounding

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you are developing a production application, we recommend using TypeScript wi
 - The rudder now uses the same sweep and chord controls as a wing
   (without mirroring or airfoil support).
 - The rudder can be shifted forward or backward along the fuselage.
-- The front and back top corners of the rudder and nacelle fins can be curved.
+- The front and back corners of the rudder and nacelle fins curve smoothly into the lower edge.
 - The fuselage can be hidden entirely if desired.
 - Elevator geometry can now be customized with independent root and tip chords,
   span, sweep, dihedral and airfoil settings.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -328,8 +328,8 @@ export default function App({ showAirfoilControls = false } = {}) {
     rudderSweep: num(0, { min: -300, max: 300, step: 1, label: 'Sweep' }),
     rudderThickness: num(2, { min: 1, max: 10, step: 0.5, label: 'Thickness' }),
     rudderOffset: num(0, { min: -100, max: 100, step: 1, label: 'Offset' }),
-    frontCornerRadius: num(0, { min: 0, max: 50, step: 1, label: 'Front Top Radius' }),
-    backCornerRadius: num(0, { min: 0, max: 50, step: 1, label: 'Back Top Radius' }),
+    frontCornerRadius: num(0, { min: 0, max: 50, step: 1, label: 'Front Corner Radius' }),
+    backCornerRadius: num(0, { min: 0, max: 50, step: 1, label: 'Back Corner Radius' }),
   });
 
   const {

--- a/src/components/Rudder.jsx
+++ b/src/components/Rudder.jsx
@@ -28,26 +28,27 @@ export default function Rudder({
     const limitedFcr = Math.min(fcr, height);
     const limitedBcr = Math.min(bcr, height);
 
+    const trailingSweep = trail(1) - trail(0);
+    const leadingSweep = lead(1) - lead(0);
+
     shape.moveTo(lead(0), 0);
     shape.lineTo(trail(0), 0);
-    shape.lineTo(trail(1), height - limitedBcr);
-    if (limitedBcr)
-      shape.quadraticCurveTo(
-        trail(1),
-        height,
-        trail(1) - limitedBcr,
-        height,
-      );
-    else shape.lineTo(trail(1), height);
+    if (limitedBcr) {
+      const bx = trail(1) - (limitedBcr * trailingSweep) / height;
+      const by = height - limitedBcr;
+      shape.lineTo(bx, by);
+      shape.quadraticCurveTo(trail(1), height, trail(1) - limitedBcr, height);
+    } else {
+      shape.lineTo(trail(1), height);
+    }
     shape.lineTo(lead(1) + limitedFcr, height);
-    if (limitedFcr)
-      shape.quadraticCurveTo(
-        lead(1),
-        height,
-        lead(1),
-        height - limitedFcr,
-      );
-    else shape.lineTo(lead(1), height);
+    if (limitedFcr) {
+      const fx = lead(1) - (limitedFcr * leadingSweep) / height;
+      const fy = height - limitedFcr;
+      shape.quadraticCurveTo(lead(1), height, fx, fy);
+    } else {
+      shape.lineTo(lead(1), height);
+    }
     shape.lineTo(lead(0), 0);
     shape.closePath();
 


### PR DESCRIPTION
## Summary
- Smoothly blend rudder corner arcs into the sloped edges so they meet the lower edge without sharp transitions
- Rename rudder UI controls to reflect corner rounding
- Document that rudder and nacelle fin corners now round into the lower edge

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Parsing error in src/lib/designState.js)*
- `npm run build` *(fails: 'import' and 'export' cannot be used outside of module code in src/lib/designState.js)*

------
https://chatgpt.com/codex/tasks/task_e_68958630f4f483308d468ec76651f932