### PR TITLE
Move theme switcher and view controls to top toolbar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -458,7 +458,12 @@ export default function App({ showAirfoilControls = false } = {}) {
 
       {/* Main Content */}
       <div style={{ flex: 1, position: 'relative', height: '100%', overflowY: 'auto' }}>
-        <ThemeSwitcher theme={theme} setTheme={setTheme} themes={themeList} />
+        <div style={{ padding: '10px', display: 'flex', gap: '10px', alignItems: 'center' }}>
+          <ThemeSwitcher theme={theme} setTheme={setTheme} themes={themeList} />
+          {!showAirfoilControls && (
+            <ViewControls controls={controlsRef} targetGroup={groupRef} />
+          )}
+        </div>
         {showAirfoilControls ? (
           <div style={{ padding: '10px' }}>{previewElements}</div>
         ) : (
@@ -503,7 +508,6 @@ export default function App({ showAirfoilControls = false } = {}) {
                 fuselageParams={fuselageParams}
               />
               <OrbitControls ref={controlsRef} />
-              <ViewControls controls={controlsRef} targetGroup={groupRef} />
             </Canvas>
             <div
               style={{
@@ -548,7 +552,7 @@ export default function App({ showAirfoilControls = false } = {}) {
                 elevatorOffset={elevatorOffset}
                 showFuselage={fuselageParams.showFuselage}
                 fuselageParams={fuselageParams}
-            
+
                />
               </MiniView>
               <MiniView position={[0, 400, 0]} up={[0, 0, 1]}>

--- a/src/components/ViewControls.jsx
+++ b/src/components/ViewControls.jsx
@@ -1,30 +1,32 @@
 import React from 'react';
-import { useThree } from '@react-three/fiber';
-import { Html } from '@react-three/drei';
 import * as THREE from 'three';
 
 export default function ViewControls({ controls, targetGroup }) {
-  const { camera } = useThree();
   const step = 20;
 
+  const getCamera = () => (controls.current ? controls.current.object : null);
+
   const pan = (dx, dy) => {
+    const camera = getCamera();
+    if (!camera || !controls.current) return;
     camera.position.x += dx * step;
     camera.position.y += dy * step;
-    if (controls.current) {
-      controls.current.target.x += dx * step;
-      controls.current.target.y += dy * step;
-      controls.current.update();
-    }
+    controls.current.target.x += dx * step;
+    controls.current.target.y += dy * step;
+    controls.current.update();
   };
 
   const zoom = (factor) => {
-    const center = controls.current ? controls.current.target : new THREE.Vector3();
+    const camera = getCamera();
+    if (!camera || !controls.current) return;
+    const center = controls.current.target.clone();
     camera.position.sub(center).multiplyScalar(factor).add(center);
-    if (controls.current) controls.current.update();
+    controls.current.update();
   };
 
   const centerView = () => {
-    if (!targetGroup.current) return;
+    const camera = getCamera();
+    if (!camera || !controls.current || !targetGroup.current) return;
     const box = new THREE.Box3().setFromObject(targetGroup.current);
     const c = new THREE.Vector3();
     box.getCenter(c);
@@ -35,24 +37,22 @@ export default function ViewControls({ controls, targetGroup }) {
   };
 
   return (
-    <Html fullscreen>
-      <div style={{ position: 'absolute', top: 20, left: 20, display: 'flex', flexDirection: 'column', gap: '4px' }}>
-        <div style={{ display: 'flex', gap: '4px', justifyContent: 'center' }}>
-          <button onClick={() => pan(0, 1)}>▲</button>
-        </div>
-        <div style={{ display: 'flex', gap: '4px' }}>
-          <button onClick={() => pan(-1, 0)}>◀</button>
-          <button onClick={centerView}>Center</button>
-          <button onClick={() => pan(1, 0)}>▶</button>
-        </div>
-        <div style={{ display: 'flex', gap: '4px', justifyContent: 'center' }}>
-          <button onClick={() => pan(0, -1)}>▼</button>
-        </div>
-        <div style={{ display: 'flex', gap: '4px', justifyContent: 'center' }}>
-          <button onClick={() => zoom(0.8)}>+</button>
-          <button onClick={() => zoom(1.25)}>-</button>
-        </div>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+      <div style={{ display: 'flex', gap: '4px', justifyContent: 'center' }}>
+        <button onClick={() => pan(0, 1)}>▲</button>
       </div>
-    </Html>
+      <div style={{ display: 'flex', gap: '4px' }}>
+        <button onClick={() => pan(-1, 0)}>◀</button>
+        <button onClick={centerView}>Center</button>
+        <button onClick={() => pan(1, 0)}>▶</button>
+      </div>
+      <div style={{ display: 'flex', gap: '4px', justifyContent: 'center' }}>
+        <button onClick={() => pan(0, -1)}>▼</button>
+      </div>
+      <div style={{ display: 'flex', gap: '4px', justifyContent: 'center' }}>
+        <button onClick={() => zoom(0.8)}>+</button>
+        <button onClick={() => zoom(1.25)}>-</button>
+      </div>
+    </div>
   );
 }

--- a/src/lib/designState.js
+++ b/src/lib/designState.js
@@ -8,7 +8,7 @@ export function getDesignState() {
   });
   return values;
 }
-codex/add-thumbnail-to-saved-designs
+
 export function getDesignThumbnail() {
   const canvas = document.querySelector('canvas');
   if (!canvas) return null;
@@ -17,6 +17,8 @@ export function getDesignThumbnail() {
   } catch {
     return null;
   }
+}
+
 export function setDesignState(values) {
   if (!values) return;
   Object.entries(values).forEach(([key, value]) => {
@@ -26,5 +28,4 @@ export function setDesignState(values) {
       /* ignore missing paths */
     }
   });
-main
 }


### PR DESCRIPTION
## Summary
- relocate theme switcher and 3D view controls to shared toolbar beneath step navigation
- refactor ViewControls for toolbar use and remove overlay
- clean up design state utilities

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68958dc1214c83309a662da8dcfb9159