### PR TITLE
Simplify view controls and unify theme colors

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -15,10 +15,10 @@
   transition: filter 300ms;
 }
 .logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
+  filter: drop-shadow(0 0 2em var(--link-color));
 }
 .logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+  filter: drop-shadow(0 0 2em var(--link-hover));
 }
 
 @keyframes logo-spin {
@@ -41,7 +41,7 @@
 }
 
 .read-the-docs {
-  color: #888;
+  color: var(--text-color);
 }
 html, body, #root {
   margin: 0;
@@ -60,5 +60,5 @@ html, body, #root {
 
 .canvas-container {
   flex: 1;
-  background-color: #111;
+  background-color: var(--bg-color);
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -431,12 +431,12 @@ export default function App({ showAirfoilControls = false } = {}) {
       {/* Sidebar: Controls + Previews */}
       <div style={{
         width: '340px',
-        backgroundColor: '#b2bfbf',
+        backgroundColor: 'var(--button-bg)',
         padding: '10px',
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
-        borderRight: '1px solid #333',
+        borderRight: '1px solid var(--link-color)',
         overflowY: 'auto'
       }}>
         <Leva collapsed={false} fill theme={levaTheme} />

--- a/src/components/AirfoilPreview.jsx
+++ b/src/components/AirfoilPreview.jsx
@@ -77,7 +77,7 @@ export default function AirfoilPreview({ chord, thickness, camber, camberPos, an
 
   return (
     <div style={{ marginTop: '16px', width: '100%' }}>
-      <div style={{ color: 'white', marginBottom: '4px' }}>{label} (inches)</div>
+      <div style={{ color: 'var(--text-color)', marginBottom: '4px' }}>{label} (inches)</div>
       <svg viewBox={viewBox} width="100%" height="200" preserveAspectRatio="xMidYMid meet">
         {/* Grid lines */}
         {gridLines.map((x, i) => (
@@ -87,17 +87,17 @@ export default function AirfoilPreview({ chord, thickness, camber, camberPos, an
             y1={-height / 2}
             x2={x}
             y2={height / 2}
-            stroke="#444"
+            stroke="var(--link-color)"
             strokeDasharray="2,2"
           />
         ))}
 
         {/* Airfoil path */}
-        <path d={pathData} stroke="cyan" fill="none" strokeWidth="1" />
+        <path d={pathData} stroke="var(--link-hover)" fill="none" strokeWidth="1" />
 
         {/* Chord edge lines */}
-        <line x1={0} y1={-height / 2} x2={0} y2={height / 2} stroke="gray" strokeDasharray="4,2" />
-        <line x1={chord} y1={-height / 2} x2={chord} y2={height / 2} stroke="gray" strokeDasharray="4,2" />
+        <line x1={0} y1={-height / 2} x2={0} y2={height / 2} stroke="var(--text-color)" strokeDasharray="4,2" />
+        <line x1={chord} y1={-height / 2} x2={chord} y2={height / 2} stroke="var(--text-color)" strokeDasharray="4,2" />
       </svg>
     </div>
   );

--- a/src/components/MiniView.jsx
+++ b/src/components/MiniView.jsx
@@ -4,7 +4,7 @@ import { OrbitControls } from '@react-three/drei';
 
 export default function MiniView({ children, position = [0, 0, 0], up = [0, 1, 0] }) {
   return (
-    <div style={{ width: 120, height: 120, border: '1px solid #333' }}>
+    <div style={{ width: 120, height: 120, border: '1px solid var(--link-color)' }}>
       <Canvas camera={{ position, up }} style={{ width: '100%', height: '100%' }}>
         <ambientLight intensity={0.5} />
         <directionalLight position={[100, 100, 100]} intensity={0.5} />

--- a/src/components/ViewControls.jsx
+++ b/src/components/ViewControls.jsx
@@ -2,27 +2,7 @@ import React from 'react';
 import * as THREE from 'three';
 
 export default function ViewControls({ controls, targetGroup }) {
-  const step = 20;
-
   const getCamera = () => (controls.current ? controls.current.object : null);
-
-  const pan = (dx, dy) => {
-    const camera = getCamera();
-    if (!camera || !controls.current) return;
-    camera.position.x += dx * step;
-    camera.position.y += dy * step;
-    controls.current.target.x += dx * step;
-    controls.current.target.y += dy * step;
-    controls.current.update();
-  };
-
-  const zoom = (factor) => {
-    const camera = getCamera();
-    if (!camera || !controls.current) return;
-    const center = controls.current.target.clone();
-    camera.position.sub(center).multiplyScalar(factor).add(center);
-    controls.current.update();
-  };
 
   const centerView = () => {
     const camera = getCamera();
@@ -37,22 +17,8 @@ export default function ViewControls({ controls, targetGroup }) {
   };
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-      <div style={{ display: 'flex', gap: '4px', justifyContent: 'center' }}>
-        <button onClick={() => pan(0, 1)}>▲</button>
-      </div>
-      <div style={{ display: 'flex', gap: '4px' }}>
-        <button onClick={() => pan(-1, 0)}>◀</button>
-        <button onClick={centerView}>Center</button>
-        <button onClick={() => pan(1, 0)}>▶</button>
-      </div>
-      <div style={{ display: 'flex', gap: '4px', justifyContent: 'center' }}>
-        <button onClick={() => pan(0, -1)}>▼</button>
-      </div>
-      <div style={{ display: 'flex', gap: '4px', justifyContent: 'center' }}>
-        <button onClick={() => zoom(0.8)}>+</button>
-        <button onClick={() => zoom(1.25)}>-</button>
-      </div>
+    <div style={{ display: 'flex', gap: '4px' }}>
+      <button onClick={centerView}>Center</button>
     </div>
   );
 }

--- a/src/design/DesignFlow.jsx
+++ b/src/design/DesignFlow.jsx
@@ -18,10 +18,10 @@ export default function DesignFlow() {
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
       <header
         style={{
-          background: '#222',
-          color: '#fff',
+          background: 'var(--bg-color)',
+          color: 'var(--text-color)',
           padding: '1rem',
-          borderBottom: '1px solid #333',
+          borderBottom: '1px solid var(--link-color)',
         }}
       >
         <ul
@@ -41,8 +41,8 @@ export default function DesignFlow() {
                 style={{
                   width: '100%',
                   padding: '0.75rem',
-                  background: current === index ? '#646cff' : '#333',
-                  color: 'inherit',
+                  background: current === index ? 'var(--link-color)' : 'var(--button-bg)',
+                  color: 'var(--text-color)',
                   border: 'none',
                   cursor: 'pointer',
                 }}


### PR DESCRIPTION
## Summary
- Collapse view controls to a single center-camera button.
- Drive UI colors from the HSV theme picker across sidebar, design steps, previews, and global styles.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b64ef0b488330aacbf6a4858e7345