### PR TITLE
fix: ensure Vite builds jsx with react plugin

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,6 @@
 </head>
 <body>
   <div id="root"></div>
-  <script type="module" src="./src/main.jsx"></script>
+  <script type="module" src="/src/main.jsx"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "three": "^0.167.0",
     "@react-three/fiber": "^8.16.1",
     "@react-three/drei": "^9.121.3",
-    "leva": "^0.9.41"
+    "leva": "^0.10.0"
   },
   "devDependencies": {
     "vite": "^5.3.3",


### PR DESCRIPTION
## Summary
- use root-based entry path so Vite pre-bundles JSX
- update leva dependency to installable version

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Rollup failed to resolve import "@mui/material" from src/components/ControlsPanel.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_689bd0c2fb708330b387c9014024ff14