### PR TITLE
Revamp interface with modern layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,13 @@
 import React, { useRef, useEffect, useState, useMemo } from 'react';
 import { Canvas, useThree } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
-import { useControls, Leva } from 'leva';
+import { useControls } from 'leva';
 import { resetNumber } from './components/ResetNumberPlugin';
 import AddPartsDrawer from './components/AddPartsDrawer.jsx';
-import ControlsPanel from './components/ControlsPanel.jsx';
+import ControlsDrawer from './components/ControlsDrawer.jsx';
 import { useUi } from './ui/UiContext.jsx';
+import { AppBar, Toolbar, IconButton, Box } from '@mui/material';
+import MenuIcon from '@mui/icons-material/Menu';
 
 function num(value, settings = {}) {
   return { value, component: resetNumber, ...settings };
@@ -45,6 +47,7 @@ function CameraCenter({ controlsRef, targetGroup }) {
 export default function App({ showAirfoilControls = false } = {}) {
   const { selectPart, enabledParts } = useUi();
   const [color, setColor] = useState({ h: 200, s: 60, v: 50 });
+  const [drawerOpen, setDrawerOpen] = useState(false);
 
   const themeColors = useMemo(() => {
     const link = hsvToHex(color.h, color.s, color.v);
@@ -436,36 +439,36 @@ export default function App({ showAirfoilControls = false } = {}) {
   }, []);
 
   return (
-    <div id="app" style={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
-      {/* Sidebar: Controls + Previews */}
-      <div
-        style={{
-          width: '340px',
-          backgroundColor: 'var(--button-bg)',
-          padding: '10px',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'stretch',
-          borderRight: '1px solid var(--link-color)',
-          overflowY: 'auto',
-          gap: '10px',
-        }}
+    <div
+      id="app"
+      style={{ height: '100vh', overflow: 'hidden', display: 'flex', flexDirection: 'column' }}
+    >
+      <AppBar
+        position="static"
+        sx={{ background: 'var(--button-bg)', color: 'var(--text-color)' }}
       >
-        <AddPartsDrawer />
-        <ControlsPanel />
-        <Leva collapsed={false} fill theme={levaTheme} />
-      </div>
-
-      {/* Main Content */}
-      <div style={{ flex: 1, position: 'relative', height: '100%', overflowY: 'auto' }}>
-        <div style={{ padding: '10px', display: 'flex', gap: '10px', alignItems: 'center' }}>
+        <Toolbar>
+          <IconButton
+            color="inherit"
+            edge="start"
+            onClick={() => setDrawerOpen(true)}
+            aria-label="open controls"
+          >
+            <MenuIcon />
+          </IconButton>
+          <Box sx={{ flexGrow: 1 }} />
+          <AddPartsDrawer />
           <ThemeSwitcher color={color} setColor={setColor} />
-          {!showAirfoilControls && (
-            <ViewControls controls={controlsRef} targetGroup={groupRef} />
-          )}
-        </div>
+        </Toolbar>
+      </AppBar>
+      <ControlsDrawer
+        open={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        levaTheme={levaTheme}
+      />
+      <Box sx={{ flex: 1, position: 'relative' }}>
         {showAirfoilControls ? (
-          <div style={{ padding: '10px' }}>{previewElements}</div>
+          <Box sx={{ p: 2 }}>{previewElements}</Box>
         ) : (
           <>
             <Canvas
@@ -513,14 +516,17 @@ export default function App({ showAirfoilControls = false } = {}) {
               />
               <OrbitControls ref={controlsRef} />
             </Canvas>
-            <div
-              style={{
+            <Box sx={{ position: 'absolute', top: 16, right: 16 }}>
+              <ViewControls controls={controlsRef} targetGroup={groupRef} />
+            </Box>
+            <Box
+              sx={{
                 position: 'absolute',
                 bottom: 20,
                 left: 20,
                 display: 'flex',
                 flexDirection: 'column',
-                gap: '10px',
+                gap: 1,
               }}
             >
               <MiniView position={[0, 0, 400]} up={[0, 1, 0]}>
@@ -530,34 +536,33 @@ export default function App({ showAirfoilControls = false } = {}) {
                   mirrored={mirrored}
                   mountHeight={mountHeight}
                   mountZ={mountZ}
-                showNacelles={showNacelles}
-                nacelleParamsList={nacelleParamsList}
-                nacelleFlags={nacelleFlags}
-                nacelleFins={nacelleFins}
-                showRudder={showRudder}
+                  showNacelles={showNacelles}
+                  nacelleParamsList={nacelleParamsList}
+                  nacelleFlags={nacelleFlags}
+                  nacelleFins={nacelleFins}
+                  showRudder={showRudder}
                   rudderHeight={rudderHeight}
                   rootChord={rootChord}
                   tipChord={tipChord}
-                rudderSweep={rudderSweep}
-                rudderThickness={rudderThickness}
-                rudderOffset={rudderOffset}
-                frontCornerRadius={frontCornerRadius}
-                backCornerRadius={backCornerRadius}
-                showElevator={showElevator}
-                elevatorRootChord={elevatorRootChord}
-                elevatorTipChord={elevatorTipChord}
-                elevatorSpan={elevatorSpan}
-                elevatorSweep={elevatorSweep}
-                elevatorDihedral={elevatorDihedral}
-                elevatorThickness={elevatorThickness}
-                elevatorCamber={elevatorCamber}
-                elevatorCamberPos={elevatorCamberPos}
-                elevatorAngle={elevatorAngle}
-                elevatorOffset={elevatorOffset}
-                showFuselage={fuselageParams.showFuselage}
-                fuselageParams={fuselageParams}
-
-               />
+                  rudderSweep={rudderSweep}
+                  rudderThickness={rudderThickness}
+                  rudderOffset={rudderOffset}
+                  frontCornerRadius={frontCornerRadius}
+                  backCornerRadius={backCornerRadius}
+                  showElevator={showElevator}
+                  elevatorRootChord={elevatorRootChord}
+                  elevatorTipChord={elevatorTipChord}
+                  elevatorSpan={elevatorSpan}
+                  elevatorSweep={elevatorSweep}
+                  elevatorDihedral={elevatorDihedral}
+                  elevatorThickness={elevatorThickness}
+                  elevatorCamber={elevatorCamber}
+                  elevatorCamberPos={elevatorCamberPos}
+                  elevatorAngle={elevatorAngle}
+                  elevatorOffset={elevatorOffset}
+                  showFuselage={fuselageParams.showFuselage}
+                  fuselageParams={fuselageParams}
+                />
               </MiniView>
               <MiniView position={[0, 400, 0]} up={[0, 0, 1]}>
                 <Aircraft
@@ -566,38 +571,38 @@ export default function App({ showAirfoilControls = false } = {}) {
                   mirrored={mirrored}
                   mountHeight={mountHeight}
                   mountZ={mountZ}
-                showNacelles={showNacelles}
-                nacelleParamsList={nacelleParamsList}
-                nacelleFlags={nacelleFlags}
-                nacelleFins={nacelleFins}
-                showRudder={showRudder}
+                  showNacelles={showNacelles}
+                  nacelleParamsList={nacelleParamsList}
+                  nacelleFlags={nacelleFlags}
+                  nacelleFins={nacelleFins}
+                  showRudder={showRudder}
                   rudderHeight={rudderHeight}
                   rootChord={rootChord}
                   tipChord={tipChord}
-                rudderSweep={rudderSweep}
-                rudderThickness={rudderThickness}
-                rudderOffset={rudderOffset}
-                frontCornerRadius={frontCornerRadius}
-                backCornerRadius={backCornerRadius}
-                showElevator={showElevator}
-                elevatorRootChord={elevatorRootChord}
-                elevatorTipChord={elevatorTipChord}
-                elevatorSpan={elevatorSpan}
-                elevatorSweep={elevatorSweep}
-                elevatorDihedral={elevatorDihedral}
-                elevatorThickness={elevatorThickness}
-                elevatorCamber={elevatorCamber}
-                elevatorCamberPos={elevatorCamberPos}
-                elevatorAngle={elevatorAngle}
-                elevatorOffset={elevatorOffset}
-                showFuselage={fuselageParams.showFuselage}
-                fuselageParams={fuselageParams}
+                  rudderSweep={rudderSweep}
+                  rudderThickness={rudderThickness}
+                  rudderOffset={rudderOffset}
+                  frontCornerRadius={frontCornerRadius}
+                  backCornerRadius={backCornerRadius}
+                  showElevator={showElevator}
+                  elevatorRootChord={elevatorRootChord}
+                  elevatorTipChord={elevatorTipChord}
+                  elevatorSpan={elevatorSpan}
+                  elevatorSweep={elevatorSweep}
+                  elevatorDihedral={elevatorDihedral}
+                  elevatorThickness={elevatorThickness}
+                  elevatorCamber={elevatorCamber}
+                  elevatorCamberPos={elevatorCamberPos}
+                  elevatorAngle={elevatorAngle}
+                  elevatorOffset={elevatorOffset}
+                  showFuselage={fuselageParams.showFuselage}
+                  fuselageParams={fuselageParams}
                 />
               </MiniView>
-            </div>
+            </Box>
           </>
         )}
-      </div>
+      </Box>
     </div>
   );
 }

--- a/src/components/AddPartsDrawer.jsx
+++ b/src/components/AddPartsDrawer.jsx
@@ -27,7 +27,7 @@ export default function AddPartsDrawer() {
       >
         <AddIcon />
       </IconButton>
-      <Drawer anchor="left" open={open} onClose={() => setOpen(false)}>
+      <Drawer anchor="right" open={open} onClose={() => setOpen(false)}>
         <List sx={{ width: 250 }}>
           {disabled.map((p) => (
             <ListItemButton

--- a/src/components/ControlsDrawer.jsx
+++ b/src/components/ControlsDrawer.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Drawer, Box } from '@mui/material';
+import ControlsPanel from './ControlsPanel.jsx';
+import { Leva } from 'leva';
+
+export default function ControlsDrawer({ open, onClose, levaTheme }) {
+  return (
+    <Drawer anchor="left" open={open} onClose={onClose}>
+      <Box sx={{ width: 340, p: 1, display: 'flex', flexDirection: 'column', gap: 1 }}>
+        <ControlsPanel />
+        <Leva collapsed={false} fill theme={levaTheme} />
+      </Box>
+    </Drawer>
+  );
+}

--- a/src/components/ThemeSwitcher.jsx
+++ b/src/components/ThemeSwitcher.jsx
@@ -1,53 +1,32 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { IconButton, Popover, Stack, Slider } from '@mui/material';
+import PaletteIcon from '@mui/icons-material/Palette';
 
 export default function ThemeSwitcher({ color, setColor }) {
-  const update = (key) => (e) => setColor({ ...color, [key]: Number(e.target.value) });
-  const sliderStyle = { width: '100%' };
-  const containerStyle = {
-    position: 'absolute',
-    top: 20,
-    right: 20,
-    zIndex: 1000,
-    background: 'var(--bg-color)',
-    padding: '10px',
-    borderRadius: '8px',
-    color: 'var(--text-color)',
-  };
+  const [anchorEl, setAnchorEl] = useState(null);
+  const open = Boolean(anchorEl);
+
+  const handleOpen = (event) => setAnchorEl(event.currentTarget);
+  const handleClose = () => setAnchorEl(null);
+  const update = (key) => (_e, value) => setColor({ ...color, [key]: value });
+
   return (
-    <div style={containerStyle}>
-      <label>
-        Hue: {color.h}
-        <input
-          type="range"
-          min="0"
-          max="360"
-          value={color.h}
-          onChange={update('h')}
-          style={sliderStyle}
-        />
-      </label>
-      <label>
-        Saturation: {color.s}
-        <input
-          type="range"
-          min="0"
-          max="100"
-          value={color.s}
-          onChange={update('s')}
-          style={sliderStyle}
-        />
-      </label>
-      <label>
-        Value: {color.v}
-        <input
-          type="range"
-          min="0"
-          max="100"
-          value={color.v}
-          onChange={update('v')}
-          style={sliderStyle}
-        />
-      </label>
-    </div>
+    <>
+      <IconButton color="inherit" onClick={handleOpen} aria-label="theme settings">
+        <PaletteIcon />
+      </IconButton>
+      <Popover
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      >
+        <Stack sx={{ p: 2, width: 200 }} spacing={2}>
+          <Slider value={color.h} min={0} max={360} onChange={update('h')} />
+          <Slider value={color.s} min={0} max={100} onChange={update('s')} />
+          <Slider value={color.v} min={0} max={100} onChange={update('v')} />
+        </Stack>
+      </Popover>
+    </>
   );
 }

--- a/src/components/ViewControls.jsx
+++ b/src/components/ViewControls.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import * as THREE from 'three';
+import { Paper, IconButton } from '@mui/material';
+import CenterFocusStrongIcon from '@mui/icons-material/CenterFocusStrong';
 
 export default function ViewControls({ controls, targetGroup }) {
   const getCamera = () => (controls.current ? controls.current.object : null);
@@ -17,8 +19,10 @@ export default function ViewControls({ controls, targetGroup }) {
   };
 
   return (
-    <div style={{ display: 'flex', gap: '4px' }}>
-      <button onClick={centerView}>Center</button>
-    </div>
+    <Paper elevation={3} sx={{ display: 'flex' }}>
+      <IconButton size="small" onClick={centerView} aria-label="center view">
+        <CenterFocusStrongIcon fontSize="small" />
+      </IconButton>
+    </Paper>
   );
 }


### PR DESCRIPTION
## Summary
- Introduce AppBar with Add Parts and Theme controls; move parameter editors to a sliding Drawer.
- Modernize theme and view controls using Material UI components and popover sliders.
- Update Add Parts drawer anchor and center view control.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d3581dc648330993b8e2065a64df9