### PR TITLE
Add airfoil-based rudder and fin geometry

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,8 @@ If you are developing a production application, we recommend using TypeScript wi
 - Optional nacelles can be added at the end of each wing panel.
 - Nacelles can be toggled per wing panel and support fuselage-style geometry options with optional top or bottom fins.
 - A rudder can be added to the rear of the fuselage.
-- The rudder now uses the same sweep and chord controls as a wing
-  (without mirroring or airfoil support).
+- The rudder and nacelle fins now use airfoil-based geometry with adjustable thickness, camber and camber position for realistic customization.
 - The rudder can be shifted forward or backward along the fuselage.
-- The front and back corners of the rudder and nacelle fins curve smoothly into the lower edge.
 - The fuselage can be hidden entirely if desired.
 - Elevator geometry can now be customized with independent root and tip chords,
   span, sweep, dihedral and airfoil settings.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -211,10 +211,10 @@ export default function App({ showAirfoilControls = false } = {}) {
       finRootChord: num(15, { min: 1, max: 100, step: 1, label: 'Fin Root Chord' }),
       finTipChord: num(0, { min: 0, max: 100, step: 1, label: 'Fin Tip Chord' }),
       finSweep: num(0, { min: -300, max: 300, step: 1, label: 'Fin Sweep' }),
-      finThickness: num(1, { min: 0.1, max: 10, step: 0.1, label: 'Fin Thickness' }),
+      finThickness: num(0.12, { min: 0.05, max: 0.25, label: 'Fin Thickness' }),
+      finCamber: num(0.02, { min: 0, max: 0.1, label: 'Fin Camber' }),
+      finCamberPos: num(0.4, { min: 0.1, max: 0.9, label: 'Fin Camber Pos' }),
       finOffset: num(0, { min: -100, max: 100, step: 1, label: 'Fin Offset' }),
-      finFrontCornerRadius: num(0, { min: 0, max: 50, step: 1, label: 'Fin Front Top Radius' }),
-      finBackCornerRadius: num(0, { min: 0, max: 50, step: 1, label: 'Fin Back Top Radius' }),
       topFinAngle: num(45, { min: -180, max: 180, step: 1, label: 'Top Fin Angle (°)' }),
       bottomFinAngle: num(-45, { min: -180, max: 180, step: 1, label: 'Bottom Fin Angle (°)' }),
     },
@@ -249,10 +249,10 @@ export default function App({ showAirfoilControls = false } = {}) {
       finRootChord: num(15, { min: 1, max: 100, step: 1, label: 'Fin Root Chord' }),
       finTipChord: num(0, { min: 0, max: 100, step: 1, label: 'Fin Tip Chord' }),
       finSweep: num(0, { min: -300, max: 300, step: 1, label: 'Fin Sweep' }),
-      finThickness: num(1, { min: 0.1, max: 10, step: 0.1, label: 'Fin Thickness' }),
+      finThickness: num(0.12, { min: 0.05, max: 0.25, label: 'Fin Thickness' }),
+      finCamber: num(0.02, { min: 0, max: 0.1, label: 'Fin Camber' }),
+      finCamberPos: num(0.4, { min: 0.1, max: 0.9, label: 'Fin Camber Pos' }),
       finOffset: num(0, { min: -100, max: 100, step: 1, label: 'Fin Offset' }),
-      finFrontCornerRadius: num(0, { min: 0, max: 50, step: 1, label: 'Fin Front Top Radius' }),
-      finBackCornerRadius: num(0, { min: 0, max: 50, step: 1, label: 'Fin Back Top Radius' }),
       topFinAngle: num(45, { min: -180, max: 180, step: 1, label: 'Top Fin Angle (°)' }),
       bottomFinAngle: num(-45, { min: -180, max: 180, step: 1, label: 'Bottom Fin Angle (°)' }),
     },
@@ -287,10 +287,10 @@ export default function App({ showAirfoilControls = false } = {}) {
       finRootChord: num(15, { min: 1, max: 100, step: 1, label: 'Fin Root Chord' }),
       finTipChord: num(0, { min: 0, max: 100, step: 1, label: 'Fin Tip Chord' }),
       finSweep: num(0, { min: -300, max: 300, step: 1, label: 'Fin Sweep' }),
-      finThickness: num(1, { min: 0.1, max: 10, step: 0.1, label: 'Fin Thickness' }),
+      finThickness: num(0.12, { min: 0.05, max: 0.25, label: 'Fin Thickness' }),
+      finCamber: num(0.02, { min: 0, max: 0.1, label: 'Fin Camber' }),
+      finCamberPos: num(0.4, { min: 0.1, max: 0.9, label: 'Fin Camber Pos' }),
       finOffset: num(0, { min: -100, max: 100, step: 1, label: 'Fin Offset' }),
-      finFrontCornerRadius: num(0, { min: 0, max: 50, step: 1, label: 'Fin Front Top Radius' }),
-      finBackCornerRadius: num(0, { min: 0, max: 50, step: 1, label: 'Fin Back Top Radius' }),
       topFinAngle: num(45, { min: -180, max: 180, step: 1, label: 'Top Fin Angle (°)' }),
       bottomFinAngle: num(-45, { min: -180, max: 180, step: 1, label: 'Bottom Fin Angle (°)' }),
     },
@@ -315,19 +315,21 @@ export default function App({ showAirfoilControls = false } = {}) {
     tipChord,
     rudderSweep,
     rudderThickness,
+    rudderCamber,
+    rudderCamberPos,
+    rudderAngle,
     rudderOffset,
-    frontCornerRadius,
-    backCornerRadius,
   } = useControls('Rudder', {
     showRudder: false,
     rudderHeight: num(40, { min: 10, max: 100, step: 1, label: 'Height' }),
     rootChord: num(30, { min: 10, max: 100, step: 1, label: 'Root Chord' }),
     tipChord: num(0, { min: 0, max: 100, step: 1, label: 'Tip Chord' }),
     rudderSweep: num(0, { min: -300, max: 300, step: 1, label: 'Sweep' }),
-    rudderThickness: num(2, { min: 1, max: 10, step: 0.5, label: 'Thickness' }),
+    rudderThickness: num(0.12, { min: 0.05, max: 0.25, label: 'Thickness' }),
+    rudderCamber: num(0.02, { min: 0, max: 0.1, label: 'Camber' }),
+    rudderCamberPos: num(0.4, { min: 0.1, max: 0.9, label: 'Camber Pos' }),
+    rudderAngle: num(0, { min: -15, max: 15, step: 0.1, label: 'Angle of Attack (°)' }),
     rudderOffset: num(0, { min: -100, max: 100, step: 1, label: 'Offset' }),
-    frontCornerRadius: num(0, { min: 0, max: 50, step: 1, label: 'Front Corner Radius' }),
-    backCornerRadius: num(0, { min: 0, max: 50, step: 1, label: 'Back Corner Radius' }),
   }, { render: () => enabledParts.includes('rudder') && !showAirfoilControls });
 
   const {
@@ -492,14 +494,15 @@ export default function App({ showAirfoilControls = false } = {}) {
                 nacelleFlags={nacelleFlags}
                 nacelleFins={nacelleFins}
                 showRudder={showRudder}
-                rudderHeight={rudderHeight}
+                height={rudderHeight}
                 rootChord={rootChord}
                 tipChord={tipChord}
                 rudderSweep={rudderSweep}
-                rudderThickness={rudderThickness}
-                rudderOffset={rudderOffset}
-                frontCornerRadius={frontCornerRadius}
-                backCornerRadius={backCornerRadius}
+                thickness={rudderThickness}
+                camber={rudderCamber}
+                camberPos={rudderCamberPos}
+                angle={rudderAngle}
+                offset={rudderOffset}
                 showElevator={showElevator}
                 elevatorRootChord={elevatorRootChord}
                 elevatorTipChord={elevatorTipChord}
@@ -541,14 +544,15 @@ export default function App({ showAirfoilControls = false } = {}) {
                   nacelleFlags={nacelleFlags}
                   nacelleFins={nacelleFins}
                   showRudder={showRudder}
-                  rudderHeight={rudderHeight}
+                  height={rudderHeight}
                   rootChord={rootChord}
                   tipChord={tipChord}
                   rudderSweep={rudderSweep}
-                  rudderThickness={rudderThickness}
-                  rudderOffset={rudderOffset}
-                  frontCornerRadius={frontCornerRadius}
-                  backCornerRadius={backCornerRadius}
+                  thickness={rudderThickness}
+                  camber={rudderCamber}
+                  camberPos={rudderCamberPos}
+                  angle={rudderAngle}
+                  offset={rudderOffset}
                   showElevator={showElevator}
                   elevatorRootChord={elevatorRootChord}
                   elevatorTipChord={elevatorTipChord}
@@ -576,14 +580,15 @@ export default function App({ showAirfoilControls = false } = {}) {
                   nacelleFlags={nacelleFlags}
                   nacelleFins={nacelleFins}
                   showRudder={showRudder}
-                  rudderHeight={rudderHeight}
+                  height={rudderHeight}
                   rootChord={rootChord}
                   tipChord={tipChord}
                   rudderSweep={rudderSweep}
-                  rudderThickness={rudderThickness}
-                  rudderOffset={rudderOffset}
-                  frontCornerRadius={frontCornerRadius}
-                  backCornerRadius={backCornerRadius}
+                  thickness={rudderThickness}
+                  camber={rudderCamber}
+                  camberPos={rudderCamberPos}
+                  angle={rudderAngle}
+                  offset={rudderOffset}
                   showElevator={showElevator}
                   elevatorRootChord={elevatorRootChord}
                   elevatorTipChord={elevatorTipChord}

--- a/src/components/Nacelle.jsx
+++ b/src/components/Nacelle.jsx
@@ -29,10 +29,10 @@ export default function Nacelle({
   finRootChord = 15,
   finTipChord = 0,
   finSweep = 0,
-  finThickness = 1,
+  finThickness = 0.12,
+  finCamber = 0.02,
+  finCamberPos = 0.4,
   finOffset = 0,
-  finFrontCornerRadius = 0,
-  finBackCornerRadius = 0,
 }) {
   const body = (
     <Fuselage
@@ -88,11 +88,11 @@ export default function Nacelle({
           height={finHeight}
           rootChord={finRootChord}
           tipChord={finTipChord}
-          sweep={finSweep}
+          rudderSweep={finSweep}
           thickness={finThickness}
+          camber={finCamber}
+          camberPos={finCamberPos}
           offset={finOffset}
-          frontCornerRadius={finFrontCornerRadius}
-          backCornerRadius={finBackCornerRadius}
           wireframe={wireframe}
         />
       </group>,
@@ -109,11 +109,11 @@ export default function Nacelle({
           height={finHeight}
           rootChord={finRootChord}
           tipChord={finTipChord}
-          sweep={finSweep}
+          rudderSweep={finSweep}
           thickness={finThickness}
+          camber={finCamber}
+          camberPos={finCamberPos}
           offset={finOffset}
-          frontCornerRadius={finFrontCornerRadius}
-          backCornerRadius={finBackCornerRadius}
           wireframe={wireframe}
         />
       </group>,

--- a/src/components/Rudder.jsx
+++ b/src/components/Rudder.jsx
@@ -1,65 +1,153 @@
 import React, { useMemo } from 'react';
 import * as THREE from 'three';
 
+function createAirfoilPoints(chord, thickness, camber, camberPos, resolution = 50) {
+  const x = Array.from({ length: resolution }, (_, i) => i / (resolution - 1));
+  const yt = x.map(xi =>
+    5 * thickness * (
+      0.2969 * Math.sqrt(xi) -
+      0.1260 * xi -
+      0.3516 * xi ** 2 +
+      0.2843 * xi ** 3 -
+      0.1015 * xi ** 4
+    )
+  );
+
+  const yc = x.map(xi => {
+    if (xi < camberPos) {
+      return (camber / (camberPos ** 2)) * (2 * camberPos * xi - xi ** 2);
+    } else {
+      return (camber / ((1 - camberPos) ** 2)) * ((1 - 2 * camberPos) + 2 * camberPos * xi - xi ** 2);
+    }
+  });
+
+  const dyc_dx = x.map(xi => {
+    if (xi < camberPos) {
+      return (2 * camber / (camberPos ** 2)) * (camberPos - xi);
+    } else {
+      return (2 * camber / ((1 - camberPos) ** 2)) * (camberPos - xi);
+    }
+  });
+
+  const theta = dyc_dx.map(dy => Math.atan(dy));
+
+  const xu = x.map((xi, i) => xi - yt[i] * Math.sin(theta[i]));
+  const yu = x.map((_, i) => yc[i] + yt[i] * Math.cos(theta[i]));
+
+  const xl = x.map((xi, i) => xi + yt[i] * Math.sin(theta[i]));
+  const yl = x.map((_, i) => yc[i] - yt[i] * Math.cos(theta[i]));
+
+  const top = xu.map((x, i) => new THREE.Vector2(x * chord, yu[i] * chord));
+  const bottom = xl.slice().reverse().map((x, i) => new THREE.Vector2(x * chord, yl.slice().reverse()[i] * chord));
+
+  return [...top, ...bottom];
+}
+
+function rotateAirfoil(points, angle, chord, pivotRatio = 1) {
+  const radians = (angle * Math.PI) / 180;
+  const cos = Math.cos(radians);
+  const sin = Math.sin(radians);
+  const pivotX = chord * pivotRatio;
+  const pivotY = 0;
+
+  return points.map((p) => {
+    const dx = p.x - pivotX;
+    const dy = p.y - pivotY;
+    const xr = dx * cos - dy * sin + pivotX;
+    const yr = dx * sin + dy * cos + pivotY;
+    return new THREE.Vector2(xr, yr);
+  });
+}
+
+function createRudderGeometry(height, root, tip, sweep) {
+  const leadCurve = 1;
+  const trailCurve = 1;
+  const vertices = [];
+  const indices = [];
+  let yOffset = 0;
+
+  const xPositions = [0, height];
+  const totalSpan = height || 1;
+  const rootChord = root.chord;
+  const tipChord = tip.chord;
+  const lead = (t) => sweep * Math.pow(t, leadCurve);
+  const trail = (t) => rootChord + (sweep + tipChord - rootChord) * Math.pow(t, trailCurve);
+
+  const sectionPoints = [root, tip].map((p, idx) => {
+    const ratio = xPositions[idx] / totalSpan;
+    const chord = p.chord;
+    let pts = createAirfoilPoints(chord, p.thickness, p.camber, p.camberPos);
+    pts = rotateAirfoil(pts, p.angle || 0, chord, (p.pivotPercent ?? 100) / 100);
+    return {
+      points: new THREE.Shape(pts).getPoints(100),
+      lead: lead(ratio),
+      trail: trail(ratio),
+      chord,
+    };
+  });
+
+  const startX = xPositions[0];
+  const endX = xPositions[1];
+  const spanLen = endX - startX;
+  const dihedralRad = ((root.dihedral || 0) * Math.PI) / 180;
+
+  const rootSec = sectionPoints[0];
+  const tipSec = sectionPoints[1];
+  const count = Math.min(rootSec.points.length, tipSec.points.length);
+  const offset = vertices.length / 3;
+  for (let i = 0; i < count; i++) {
+    const rp = rootSec.points[i];
+    const tp = tipSec.points[i];
+    if (!rp || !tp) continue;
+    const startY = rp.y + yOffset;
+    const endY = tp.y + yOffset + Math.tan(dihedralRad) * spanLen;
+    const rRatio = rp.x / rootSec.chord;
+    const tRatio = tp.x / tipSec.chord;
+    const rZ = rootSec.lead + rRatio * (rootSec.trail - rootSec.lead);
+    const tZ = tipSec.lead + tRatio * (tipSec.trail - tipSec.lead);
+    vertices.push(startX, startY, rZ);
+    vertices.push(endX, endY, tZ);
+  }
+  for (let i = 0; i < count - 1; i++) {
+    const r1 = offset + 2 * i;
+    const t1 = offset + 2 * i + 1;
+    const r2 = offset + 2 * (i + 1);
+    const t2 = offset + 2 * (i + 1) + 1;
+    indices.push(r1, t1, r2);
+    indices.push(t1, t2, r2);
+  }
+  yOffset += Math.tan(dihedralRad) * spanLen;
+
+  const geom = new THREE.BufferGeometry();
+  geom.setAttribute('position', new THREE.BufferAttribute(new Float32Array(vertices), 3));
+  geom.setIndex(indices);
+  geom.computeVertexNormals();
+  return geom;
+}
+
 export default function Rudder({
   height = 40,
   rootChord = 30,
   tipChord = 20,
-  sweep = 0,
-  thickness = 2,
+  rudderSweep = 0,
+  thickness = 0.12,
+  camber = 0.02,
+  camberPos = 0.4,
+  angle = 0,
   offset = 0,
-  frontCornerRadius = 0,
-  backCornerRadius = 0,
   wireframe = false,
   position = [0, 0, 0],
   rotation = [0, 0, 0],
 }) {
+  const sweep = rudderSweep;
   const geom = useMemo(() => {
-    const shape = new THREE.Shape();
-
-    const lead = (t) => sweep * t;
-    const trail = (t) => rootChord + (sweep + tipChord - rootChord) * t;
-
-    // The front and back corner radii are intentionally swapped so that the
-    // "front" parameter controls the corner nearest the trailing edge and vice
-    // versa. This matches the expected layout of the UI controls.
-    let fcr = Math.max(0, backCornerRadius);
-    let bcr = Math.max(0, frontCornerRadius);
-    const topWidth = trail(1) - lead(1);
-    if (bcr > topWidth) bcr = topWidth;
-    if (fcr > topWidth - bcr) fcr = topWidth - bcr;
-    const limitedFcr = Math.min(fcr, height);
-    const limitedBcr = Math.min(bcr, height);
-
-    const trailingSweep = trail(1) - trail(0);
-    const leadingSweep = lead(1) - lead(0);
-
-    shape.moveTo(lead(0), 0);
-    shape.lineTo(trail(0), 0);
-    if (limitedBcr) {
-      const bx = trail(1) - (limitedBcr * trailingSweep) / height;
-      const by = height - limitedBcr;
-      shape.lineTo(bx, by);
-      shape.quadraticCurveTo(trail(1), height, trail(1) - limitedBcr, height);
-    } else {
-      shape.lineTo(trail(1), height);
-    }
-    shape.lineTo(lead(1) + limitedFcr, height);
-    if (limitedFcr) {
-      const fx = lead(1) - (limitedFcr * leadingSweep) / height;
-      const fy = height - limitedFcr;
-      shape.quadraticCurveTo(lead(1), height, fx, fy);
-    } else {
-      shape.lineTo(lead(1), height);
-    }
-    shape.lineTo(lead(0), 0);
-    shape.closePath();
-
-    const g = new THREE.ExtrudeGeometry(shape, { depth: thickness, bevelEnabled: false });
-    g.rotateY(Math.PI / 2);
-    g.translate(-thickness / 2, 0, 0);
+    const root = { chord: rootChord, thickness, camber, camberPos, angle, length: height };
+    const tip = { chord: tipChord, thickness, camber, camberPos, angle, length: 0 };
+    const g = createRudderGeometry(height, root, tip, sweep);
+    g.rotateZ(Math.PI / 2);
+    g.scale(-1, 1, 1);
     return g;
-  }, [height, rootChord, tipChord, sweep, thickness, backCornerRadius, frontCornerRadius]);
+  }, [height, rootChord, tipChord, sweep, thickness, camber, camberPos, angle]);
 
   const finalPos = [position[0], position[1], position[2] + offset];
 


### PR DESCRIPTION
## Summary
- replace rudder mesh with airfoil-based geometry supporting thickness, camber, and sweep
- forward the same airfoil parameters to nacelle fins for consistent customization
- expose new rudder and fin controls in the UI and update documentation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d3f411ddc83308a8be4a86791b286