### PR TITLE
Fix rudder sweep and remove nacelle at wing root

### DIFF
--- a/src/components/Aircraft.jsx
+++ b/src/components/Aircraft.jsx
@@ -33,6 +33,7 @@ export default function Aircraft(props) {
         if (!item) return null;
         const Component = item.Component;
         if (id === 'fuselage' && !props.showFuselage) return null;
+        if (id === 'rudder' && !props.showRudder) return null;
         return (
           <group
             key={id}

--- a/src/components/Rudder.jsx
+++ b/src/components/Rudder.jsx
@@ -5,7 +5,7 @@ export default function Rudder({
   height = 40,
   rootChord = 30,
   tipChord = 20,
-  sweep = 0,
+  rudderSweep = 0,
   thickness = 2,
   offset = 0,
   frontCornerRadius = 0,
@@ -14,6 +14,7 @@ export default function Rudder({
   position = [0, 0, 0],
   rotation = [0, 0, 0],
 }) {
+  const sweep = rudderSweep;
   const geom = useMemo(() => {
     const shape = new THREE.Shape();
 

--- a/src/components/Wing.jsx
+++ b/src/components/Wing.jsx
@@ -162,7 +162,7 @@ function computeNacellePositions(sections, sweep) {
   const leadCurve = 1;
   const trailCurve = 1;
   const xPositions = [0];
-  for (let i = 0; i < sections.length - 1; i++) {
+  for (let i = 0; i < sections.length; i++) {
     const len = sections[i].length || 0;
     xPositions.push(xPositions[i] + len);
   }
@@ -172,11 +172,12 @@ function computeNacellePositions(sections, sweep) {
   const rootChord = sections[0].chord || 0;
   const tipChord = sections[sections.length - 1].chord || 0;
   const lead = (t) => sweep * Math.pow(t, leadCurve);
-  const trail = (t) => rootChord + (sweep + tipChord - rootChord) * Math.pow(t, trailCurve);
+  const trail = (t) =>
+    rootChord + (sweep + tipChord - rootChord) * Math.pow(t, trailCurve);
 
   let yOffset = 0;
   const positions = [];
-  for (let s = 0; s < sections.length - 1; s++) {
+  for (let s = 0; s < sections.length; s++) {
     const startX = xPositions[s];
     const endX = xPositions[s + 1];
     const spanLen = endX - startX;
@@ -188,6 +189,7 @@ function computeNacellePositions(sections, sweep) {
     const z = l + (tr - l) / 2;
     positions.push([endX, yOffset, z]);
   }
+  positions.shift();
   return positions;
 }
 


### PR DESCRIPTION
## Summary
- decouple rudder sweep from wing sweep
- avoid nacelles appearing at wing root
- hide rudder mesh until explicitly enabled

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689d539c43d88330a4c2f3134d99500d