### PR TITLE
feat: add parts drawer and persistent controls panel

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,11 +3,11 @@ import { Canvas, useThree } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
 import { useControls } from 'leva';
 import { resetNumber } from './components/ResetNumberPlugin';
-import AddPartsDrawer from './components/AddPartsDrawer.jsx';
-import ControlsDrawer from './components/ControlsDrawer.jsx';
+import PartsDrawer from './components/PartsDrawer.jsx';
+import ControlsPanel from './components/ControlsPanel.jsx';
+import { Leva } from 'leva';
 import { useUi } from './ui/UiContext.jsx';
-import { AppBar, Toolbar, IconButton, Box } from '@mui/material';
-import MenuIcon from '@mui/icons-material/Menu';
+import { AppBar, Toolbar, Box } from '@mui/material';
 
 function num(value, settings = {}) {
   return { value, component: resetNumber, ...settings };
@@ -47,7 +47,6 @@ function CameraCenter({ controlsRef, targetGroup }) {
 export default function App({ showAirfoilControls = false } = {}) {
   const { selectPart, enabledParts } = useUi();
   const [color, setColor] = useState({ h: 200, s: 60, v: 50 });
-  const [drawerOpen, setDrawerOpen] = useState(false);
 
   const themeColors = useMemo(() => {
     const link = hsvToHex(color.h, color.s, color.v);
@@ -448,37 +447,25 @@ export default function App({ showAirfoilControls = false } = {}) {
         sx={{ background: 'var(--button-bg)', color: 'var(--text-color)' }}
       >
         <Toolbar>
-          <IconButton
-            color="inherit"
-            edge="start"
-            onClick={() => setDrawerOpen(true)}
-            aria-label="open controls"
-          >
-            <MenuIcon />
-          </IconButton>
+          <PartsDrawer />
           <Box sx={{ flexGrow: 1 }} />
-          <AddPartsDrawer />
           <ThemeSwitcher color={color} setColor={setColor} />
         </Toolbar>
       </AppBar>
-      <ControlsDrawer
-        open={drawerOpen}
-        onClose={() => setDrawerOpen(false)}
-        levaTheme={levaTheme}
-      />
-      <Box sx={{ flex: 1, position: 'relative' }}>
-        {showAirfoilControls ? (
-          <Box sx={{ p: 2 }}>{previewElements}</Box>
-        ) : (
-          <>
-            <Canvas
-              style={{ width: '100%', height: '100%' }}
-              camera={{ position: [0, 0, 400], fov: 50 }}
-              onPointerMissed={() => selectPart(null)}
-            >
-              <ResizeHandler />
-              <CameraCenter controlsRef={controlsRef} targetGroup={groupRef} />
-              <ambientLight intensity={0.5} />
+      <Box sx={{ display: 'flex', flex: 1, position: 'relative' }}>
+        <Box sx={{ flex: 1, position: 'relative' }}>
+          {showAirfoilControls ? (
+            <Box sx={{ p: 2 }}>{previewElements}</Box>
+          ) : (
+            <>
+              <Canvas
+                style={{ width: '100%', height: '100%' }}
+                camera={{ position: [0, 0, 400], fov: 50 }}
+                onPointerMissed={() => selectPart(null)}
+              >
+                <ResizeHandler />
+                <CameraCenter controlsRef={controlsRef} targetGroup={groupRef} />
+                <ambientLight intensity={0.5} />
               <directionalLight position={[1, 2, 3]} intensity={1} />
               <Aircraft
                 groupRef={groupRef}
@@ -602,6 +589,20 @@ export default function App({ showAirfoilControls = false } = {}) {
             </Box>
           </>
         )}
+        </Box>
+        <Box
+          sx={{
+            width: 340,
+            p: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 1,
+            overflow: 'auto',
+          }}
+        >
+          <ControlsPanel />
+          <Leva collapsed={false} fill theme={levaTheme} />
+        </Box>
       </Box>
     </div>
   );

--- a/src/components/ControlsPanel.jsx
+++ b/src/components/ControlsPanel.jsx
@@ -1,31 +1,59 @@
 import React from 'react';
-import { Box, Collapse, Paper, Typography } from '@mui/material';
+import { Box, Typography, IconButton } from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
 import { useUi } from '../ui/UiContext.jsx';
 
 export default function ControlsPanel() {
-  const { registry, enabledParts, selectedPartId, selectPart } = useUi();
+  const {
+    registry,
+    enabledParts,
+    selectedPartId,
+    selectPart,
+    disablePart,
+  } = useUi();
+
+  if (!selectedPartId) {
+    return (
+      <Box sx={{ width: 300, p: 1 }}>
+        <Typography variant="h6" gutterBottom>
+          Aircraft / View
+        </Typography>
+        <Typography variant="body2">No part selected.</Typography>
+      </Box>
+    );
+  }
+
+  if (!enabledParts.includes(selectedPartId)) {
+    const item = registry[selectedPartId];
+    return (
+      <Box sx={{ width: 300, p: 1 }}>
+        <Typography variant="body2" sx={{ mb: 1 }}>
+          This part isn’t added. Add it in Parts Manager.
+        </Typography>
+      </Box>
+    );
+  }
+
+  const item = registry[selectedPartId];
+  if (!item) return null;
+  const Controls = item.Controls;
 
   return (
     <Box sx={{ width: 300, overflow: 'auto', p: 1 }}>
-      {enabledParts.map((id) => {
-        const item = registry[id];
-        if (!item) return null;
-        const Controls = item.Controls;
-        const open = selectedPartId === id;
-        return (
-          <Paper key={id} sx={{ mb: 1 }}>
-            <Typography
-              sx={{ p: 1, cursor: 'pointer', fontWeight: open ? 'bold' : 'normal' }}
-              onClick={() => selectPart(open ? null : id)}
-            >
-              {item.label}
-            </Typography>
-            <Collapse in={open} timeout="auto" unmountOnExit>
-              <Box sx={{ p: 1 }}>{Controls ? <Controls partId={id} /> : null}</Box>
-            </Collapse>
-          </Paper>
-        );
-      })}
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
+        <Typography variant="h6">{item.label}</Typography>
+        <IconButton
+          size="small"
+          onClick={() => {
+            disablePart(item.id);
+            selectPart(null);
+          }}
+        >
+          <DeleteIcon fontSize="small" />
+        </IconButton>
+      </Box>
+      {Controls ? <Controls partId={selectedPartId} /> : null}
     </Box>
   );
 }
+

--- a/src/components/PartsDrawer.jsx
+++ b/src/components/PartsDrawer.jsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import {
+  Drawer,
+  IconButton,
+  List,
+  ListItemButton,
+  ListItemText,
+} from '@mui/material';
+import MenuIcon from '@mui/icons-material/Menu';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { useUi } from '../ui/UiContext.jsx';
+
+export default function PartsDrawer() {
+  const {
+    registry,
+    enabledParts,
+    enablePart,
+    disablePart,
+    selectPart,
+    selectedPartId,
+  } = useUi();
+  const [open, setOpen] = useState(false);
+
+  const parts = Object.values(registry);
+
+  return (
+    <>
+      <IconButton
+        color="inherit"
+        edge="start"
+        onClick={() => setOpen(true)}
+        aria-label="open parts manager"
+      >
+        <MenuIcon />
+      </IconButton>
+      <Drawer anchor="left" open={open} onClose={() => setOpen(false)}>
+        <List sx={{ width: 250 }}>
+          {parts.map((p) => {
+            const enabled = enabledParts.includes(p.id);
+            return (
+              <ListItemButton
+                key={p.id}
+                selected={selectedPartId === p.id}
+                onClick={() => {
+                  if (!enabled) enablePart(p.id);
+                  selectPart(p.id);
+                  setOpen(false);
+                }}
+              >
+                <ListItemText primary={p.label} />
+                {enabled && (
+                  <IconButton
+                    edge="end"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      disablePart(p.id);
+                      if (selectedPartId === p.id) selectPart(null);
+                    }}
+                  >
+                    <DeleteIcon />
+                  </IconButton>
+                )}
+              </ListItemButton>
+            );
+          })}
+        </List>
+      </Drawer>
+    </>
+  );
+}
+


### PR DESCRIPTION
## Summary
- replace temporary drawers with a dedicated PartsDrawer for adding, selecting, and removing parts
- show part controls in a permanent right-side panel with a global fallback when nothing is selected
- restructure app layout so the 3D canvas and control panel share a unified layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689e411680d083309b49361a6bed5fd5