### PR TITLE
Fix resize layout and hide disabled part controls

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -54,8 +54,7 @@ html, body, #root {
 
 #app {
   display: flex;
-  height: 100vh;
-  width: 100vw;
+  flex-direction: column;
 }
 
 .canvas-container {

--- a/src/components/Aircraft.jsx
+++ b/src/components/Aircraft.jsx
@@ -12,7 +12,7 @@ import { useUi } from '../ui/UiContext.jsx';
  * work. Each rendered part is wrapped in a group with a partId so the 3D view
  * can determine which part was clicked.
  */
-export default function Aircraft(props) {
+export default function Aircraft({ groupRef, ...props }) {
   const { enabledParts, registry, registerParts, selectPart } = useUi();
 
   // register known parts on mount
@@ -27,7 +27,7 @@ export default function Aircraft(props) {
   }, [registerParts]);
 
   return (
-    <group>
+    <group ref={groupRef}>
       {enabledParts.map((id) => {
         const item = registry[id];
         if (!item) return null;


### PR DESCRIPTION
## Summary
- keep app layout in sync with window size so top bar and control panel stay visible
- recenter camera on the model when viewport changes
- hide wing and nacelle sliders unless the corresponding parts are enabled

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e4cbcb59c8330a15111bb7cd0c219