### PR TITLE
Fix camera centering to respect viewport size

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,7 +12,6 @@ import { AppBar, Toolbar, Box } from '@mui/material';
 function num(value, settings = {}) {
   return { value, component: resetNumber, ...settings };
 }
-import * as THREE from 'three';
 import './App.css';
 import AirfoilPreview from './components/AirfoilPreview';
 import ViewControls from './components/ViewControls';
@@ -20,6 +19,7 @@ import Aircraft from './components/Aircraft';
 import MiniView from './components/MiniView';
 import ThemeSwitcher from './components/ThemeSwitcher';
 import { hsvToHex, adjustHSV } from './lib/color';
+import { fitCameraToObject } from './lib/camera';
 function ResizeHandler() {
   const { camera, size } = useThree();
   useEffect(() => {
@@ -33,16 +33,7 @@ function CameraCenter({ controlsRef, targetGroup, enabledParts }) {
   const { camera, size } = useThree();
   useEffect(() => {
     if (!controlsRef.current || !targetGroup.current) return;
-    const box = new THREE.Box3().setFromObject(targetGroup.current);
-    const center = new THREE.Vector3();
-    box.getCenter(center);
-    const offset = new THREE.Vector3().subVectors(
-      camera.position,
-      controlsRef.current.target
-    );
-    controlsRef.current.target.copy(center);
-    camera.position.copy(center.clone().add(offset));
-    controlsRef.current.update();
+    fitCameraToObject(camera, controlsRef.current, targetGroup.current, size);
   }, [camera, controlsRef, targetGroup, size, enabledParts]);
   return null;
 }
@@ -446,18 +437,6 @@ export default function App({ showAirfoilControls = false } = {}) {
     </>
   );
 
-  // Center the orbit controls on the aircraft when it is first rendered
-  useEffect(() => {
-    if (!controlsRef.current || !groupRef.current) return;
-    const box = new THREE.Box3().setFromObject(groupRef.current);
-    const center = new THREE.Vector3();
-    box.getCenter(center);
-    const camera = controlsRef.current.object;
-    const offset = new THREE.Vector3().subVectors(camera.position, controlsRef.current.target);
-    controlsRef.current.target.copy(center);
-    camera.position.copy(center.clone().add(offset));
-    controlsRef.current.update();
-  }, []);
 
   return (
     <div

--- a/src/components/ViewControls.jsx
+++ b/src/components/ViewControls.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import * as THREE from 'three';
 import { Paper, IconButton } from '@mui/material';
 import CenterFocusStrongIcon from '@mui/icons-material/CenterFocusStrong';
+import { fitCameraToObject } from '../lib/camera';
 
 export default function ViewControls({ controls, targetGroup }) {
   const getCamera = () => (controls.current ? controls.current.object : null);
@@ -9,13 +9,8 @@ export default function ViewControls({ controls, targetGroup }) {
   const centerView = () => {
     const camera = getCamera();
     if (!camera || !controls.current || !targetGroup.current) return;
-    const box = new THREE.Box3().setFromObject(targetGroup.current);
-    const c = new THREE.Vector3();
-    box.getCenter(c);
-    const offset = new THREE.Vector3().subVectors(camera.position, controls.current.target);
-    controls.current.target.copy(c);
-    camera.position.copy(c.clone().add(offset));
-    controls.current.update();
+    const { clientWidth: width, clientHeight: height } = controls.current.domElement;
+    fitCameraToObject(camera, controls.current, targetGroup.current, { width, height });
   };
 
   return (

--- a/src/lib/camera.js
+++ b/src/lib/camera.js
@@ -1,0 +1,45 @@
+import * as THREE from 'three';
+
+export function fitCameraToObject(camera, controls, object, size, fitOffset = 1.2) {
+  if (!camera || !object) return;
+  const box = new THREE.Box3().setFromObject(object);
+  const center = box.getCenter(new THREE.Vector3());
+  const boxSize = box.getSize(new THREE.Vector3());
+  const aspect = size.width / size.height;
+
+  if (camera.isPerspectiveCamera) {
+    const fov = THREE.MathUtils.degToRad(camera.fov);
+    const fitHeightDistance = boxSize.y / (2 * Math.tan(fov / 2));
+    const fitWidthDistance = boxSize.x / (2 * Math.tan(fov / 2)) / aspect;
+    const distance = fitOffset * Math.max(fitHeightDistance, fitWidthDistance);
+    const direction = camera.position
+      .clone()
+      .sub(controls?.target || new THREE.Vector3())
+      .normalize();
+    camera.aspect = aspect;
+    camera.position.copy(center.clone().add(direction.multiplyScalar(distance)));
+    camera.near = distance / 100;
+    camera.far = distance * 100;
+  } else if (camera.isOrthographicCamera) {
+    const halfWidth = (boxSize.x / 2) * fitOffset;
+    const halfHeight = (boxSize.y / 2) * fitOffset;
+    camera.left = -halfWidth;
+    camera.right = halfWidth;
+    camera.top = halfHeight;
+    camera.bottom = -halfHeight;
+    camera.near = -boxSize.z * fitOffset;
+    camera.far = boxSize.z * fitOffset;
+    const direction = camera.position
+      .clone()
+      .sub(controls?.target || new THREE.Vector3())
+      .normalize();
+    const distance = boxSize.z * fitOffset;
+    camera.position.copy(center.clone().add(direction.multiplyScalar(distance)));
+  }
+
+  camera.updateProjectionMatrix();
+  if (controls) {
+    controls.target.copy(center);
+    controls.update();
+  }
+}


### PR DESCRIPTION
## Summary
- adjust camera centering logic to fit model in current viewport
- add utility to compute bounding-box based framing for perspective or orthographic cameras
- ensure center view button uses viewport-aware camera framing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689e51c5fcac83308df225ffb75ec969