### PR TITLE
Ensure side menus remain visible on resize

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -459,8 +459,14 @@ export default function App({ showAirfoilControls = false } = {}) {
           <ThemeSwitcher color={color} setColor={setColor} />
         </Toolbar>
       </AppBar>
-      <Box sx={{ display: 'flex', flex: 1, position: 'relative' }}>
-        <Box sx={{ flex: 1, position: 'relative' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          flex: 1,
+          position: 'relative',
+        }}
+      >
+        <Box sx={{ flex: 1, minWidth: 0, position: 'relative' }}>
           {showAirfoilControls ? (
             <Box sx={{ p: 2 }}>{previewElements}</Box>
           ) : (
@@ -603,7 +609,9 @@ export default function App({ showAirfoilControls = false } = {}) {
         </Box>
         <Box
           sx={{
-            width: 340,
+            width: { xs: 260, sm: 340 },
+            minWidth: { xs: 260, sm: 340 },
+            flexShrink: 0,
             p: 1,
             display: 'flex',
             flexDirection: 'column',


### PR DESCRIPTION
## Summary
- Prevent 3D canvas from collapsing side panels by giving the canvas container a `minWidth: 0`.
- Keep right-hand control menus visible with responsive `width`/`minWidth` values and `flexShrink: 0` so they maintain a minimum width.

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689e53f7bf688330a866112c53b224b0